### PR TITLE
Improved JSON output

### DIFF
--- a/pkg/parser/k8s_query.go
+++ b/pkg/parser/k8s_query.go
@@ -469,13 +469,18 @@ func (q *QueryExecutor) Execute(ast *Expression) (interface{}, error) {
 					pathStr = "$." + pathStr
 				}
 
-				// Create a map for the node's resources
-				results[nodeId] = []interface{}{}
+				// Create a map for the node's resources if it's empty
+				if results[nodeId] == nil {
+					results[nodeId] = []interface{}{}
+				}
 
 				// Iterate over the resources in the result map
 				for idx, resource := range resultMap[nodeId].([]map[string]interface{}) {
-					// create a new empty slice in results[nodeId][idx]
-					results[nodeId] = append(results[nodeId].([]interface{}), make(map[string]interface{}))
+					// if it doesn't exist, create a new empty slice in results[nodeId][idx]
+
+					if len(results[nodeId].([]interface{})) <= idx {
+						results[nodeId] = append(results[nodeId].([]interface{}), make(map[string]interface{}))
+					}
 					currentMap := results[nodeId].([]interface{})[idx].(map[string]interface{})
 
 					// assign

--- a/pkg/parser/k8s_query.go
+++ b/pkg/parser/k8s_query.go
@@ -101,7 +101,8 @@ func (q *QueryExecutor) Execute(ast *Expression) (interface{}, error) {
 				}
 
 				matchedResources := applyRelationshipRule(resourcesA, resourcesB, rule, filteredDirection)
-				resultMap[rel.RightNode.ResourceProperties.Name] = matchedResources
+				resultMap[rel.RightNode.ResourceProperties.Name] = matchedResources["right"]
+				resultMap[rel.LeftNode.ResourceProperties.Name] = matchedResources["left"]
 			}
 
 			// Iterate over the nodes in the match clause.

--- a/pkg/parser/relationships.go
+++ b/pkg/parser/relationships.go
@@ -394,20 +394,34 @@ func matchOwnerReferences(ownerRefs []interface{}, name string) bool {
 	return false
 }
 
-func applyRelationshipRule(resourcesA, resourcesB []map[string]interface{}, rule RelationshipRule, direction Direction) []map[string]interface{} {
-	var matchedResources []map[string]interface{}
+func applyRelationshipRule(resourcesA, resourcesB []map[string]interface{}, rule RelationshipRule, direction Direction) map[string]interface{} {
+	var matchedResourcesA []map[string]interface{}
+	var matchedResourcesB []map[string]interface{}
+
 	for _, resourceA := range resourcesA {
 		for _, resourceB := range resourcesB {
 			if matchByCriteria(resourceA, resourceB, rule.MatchCriteria) {
 				if direction == Left {
-					matchedResources = append(matchedResources, resourceA)
+					matchedResourcesA = append(matchedResourcesA, resourceA)
+					matchedResourcesB = append(matchedResourcesB, resourceB)
 				} else if direction == Right {
-					matchedResources = append(matchedResources, resourceB)
+					matchedResourcesA = append(matchedResourcesA, resourceB)
+					matchedResourcesB = append(matchedResourcesB, resourceA)
 				} else {
 					return nil
 				}
 			}
 		}
 	}
+
+	// initialize matchedResources map
+	matchedResources := make(map[string]interface{})
+
+	// return the matched resources as a slice of maps that looks like this:
+	// matchedresources["right"] = matchedResourcesA
+	// matchedresources["left"] = matchedResourcesB
+	matchedResources["right"] = matchedResourcesA
+	matchedResources["left"] = matchedResourcesB
+
 	return matchedResources
 }


### PR DESCRIPTION
3 major changes:
* The JSON output generated by return clauses was previously broken, it would create a structure like this:

```json
"d": {
  "metadata": {
    "name": [
      "foo",
      "bar",
    ]
  }
}
```

instead of this:

```json
"d": [
  {
    "metadata": {
      "name": "foo"
    }
  },
  {
    "metadata": {
      "name": "bar"
    }
  }  
]
```
This PR fixes this issue

* Relationships are now correctly filtered on both ends, meaning resources are filtered to match the relationship pattern no matter which side of the edge they're on

* Moved the extraFilters function to the `getNodeResources` function so that filtering happens pre-applying relationship rules