### PR TITLE
V0.11.1

### DIFF
--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/avitaltamir/cyphernetes/pkg/parser"
 	cobra "github.com/spf13/cobra"
 	"github.com/wader/readline"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -193,6 +193,7 @@ func runShell(cmd *cobra.Command, args []string) {
 		DisableAutoSaveHistory: true,
 		HistorySearchFold:      true,
 		FuncFilterInputRune:    filterInput,
+		UniqueEditLine:         true,
 	})
 	if err != nil {
 		panic(err)
@@ -227,6 +228,7 @@ func runShell(cmd *cobra.Command, args []string) {
 
 	for {
 		line, err := rl.Readline()
+		fmt.Print("\n")
 		if err != nil {
 			if err == readline.ErrInterrupt {
 				if len(line) == 0 {

--- a/pkg/parser/k8s_client.go
+++ b/pkg/parser/k8s_client.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
This release resolves several issues with the v0.11.0 release:

* No more screen tearing - prompt will no longer be printed until query is resolved, and will always provide a newline
* Support OIDC client configuration
* Allow deletion and patching of resources in all-namespaces mode