### PR TITLE
fix(k8s-client): use full client config loading rules

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,6 +22,8 @@ jobs:
         go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
         setup-envtest use
         echo "KUBEBUILDER_ASSETS=$(setup-envtest use -p path)" >> $GITHUB_ENV
+    - name: Create a link to envtest in operator/bin
+      run: ln -s $(which setup-envtest) operator/bin/setup-envtest
     - name: Install goyacc
       run: go install golang.org/x/tools/cmd/goyacc@latest
     - name: Create the operator manifests

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,6 +30,8 @@ jobs:
       run: make operator-manifests
     - name: Run tests
       run: make test
+    - name: Apply operator test CRDs
+      run: kubectl apply -f ./operator/test/e2e/samples/crd-exposeddeployments.yaml
     - name: Run operator tests
       env:
         KUBEBUILDER_ASSETS: ${{ env.KUBEBUILDER_ASSETS }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
         setup-envtest use
         echo "KUBEBUILDER_ASSETS=$(setup-envtest use -p path)" >> $GITHUB_ENV
     - name: Create a link to envtest in operator/bin
-      run: ln -s $(which setup-envtest) operator/bin/setup-envtest
+      run: mkdir -p ./operator/bin && ln -s $(which setup-envtest) ./operator/bin/setup-envtest
     - name: Install goyacc
       run: go install golang.org/x/tools/cmd/goyacc@latest
     - name: Create the operator manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
@@ -95,6 +96,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
+	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20241005135803-3f6485a69964 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -921,6 +921,7 @@ github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZ
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
@@ -1705,6 +1706,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsA
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC0ji/Q=
 sigs.k8s.io/controller-runtime v0.19.0/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20241005135803-3f6485a69964 h1:7trb679xWdb6VcsXI2hTCCcMEtfKl2b2tajFRgDpLCg=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20241005135803-3f6485a69964/go.mod h1:IaDsO8xSPRxRG1/rm9CP7+jPmj0nMNAuNi/yiHnLX8k=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=

--- a/pkg/parser/k8s_client.go
+++ b/pkg/parser/k8s_client.go
@@ -510,8 +510,3 @@ func resolveReference(ref string) *openapi_v3.Schema {
 	// fmt.Printf("Schema not found for ref: %s\n", ref)
 	return nil
 }
-
-// func init() {
-// 	// Initialize the executorInstance
-// 	GetQueryExecutorInstance()
-// }

--- a/pkg/parser/k8s_client.go
+++ b/pkg/parser/k8s_client.go
@@ -59,33 +59,33 @@ type apiResponse struct {
 }
 
 func NewQueryExecutor() (*QueryExecutor, error) {
-	// Use the local kubeconfig context
-	// Try to use the in-cluster config first
-	config, err := rest.InClusterConfig()
+	var config *rest.Config
+	var err error
+
+	// First, try to use in-cluster config
+	config, err = rest.InClusterConfig()
 	if err != nil {
-		// If that fails, fall back to kubeconfig
-		config, err = clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+		// If that fails, use the kubeconfig file(s)
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		configOverrides := &clientcmd.ConfigOverrides{}
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+		config, err = kubeConfig.ClientConfig()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create config: %v", err)
+			return nil, fmt.Errorf("failed to create config: not found in $KUBECONFIG, ~/.kube/config, or in-cluster")
 		}
-	}
-	if err != nil {
-		fmt.Println("Error creating in-cluster config")
-		return nil, err
 	}
 
 	// Create the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		fmt.Println("Error creating clientset")
-		return nil, err
+		return nil, fmt.Errorf("error creating clientset: %v", err)
 	}
 
 	// Create the dynamic client
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		fmt.Println("Error creating dynamic client")
-		return nil, err
+		return nil, fmt.Errorf("error creating dynamic client: %v", err)
 	}
 
 	// Initialize the semaphore with a desired concurrency level
@@ -511,7 +511,7 @@ func resolveReference(ref string) *openapi_v3.Schema {
 	return nil
 }
 
-func init() {
-	// Initialize the executorInstance
-	GetQueryExecutorInstance()
-}
+// func init() {
+// 	// Initialize the executorInstance
+// 	GetQueryExecutorInstance()
+// }


### PR DESCRIPTION
Make sure we're respecting $KUBECONFIG, rest config, recommended home file and all regular config loading rules.
This PR also fixes a bug: Exit with error instead of panic when failing to load config

Additionally, there's a small fix here to the operator tests which didn't run successfully but still passed previously.