### PR TITLE
feat: discover relationships by property name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,15 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "CLI:Query",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/cyphernetes",
+            "args": ["query", "MATCH (p:pod) RETURN count{p}"],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "CLI:Test",
             "type": "go",
             "request": "launch",

--- a/cmd/cyphernetes/query.go
+++ b/cmd/cyphernetes/query.go
@@ -22,6 +22,8 @@ var queryCmd = &cobra.Command{
 	Long:  `Use the 'query' subcommand to execute a single Cypher-inspired query against your Kubernetes resources.`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		parser.CleanOutput = true
+		parser.InitResourceSpecs()
 		runQuery(args, os.Stdout)
 	},
 }

--- a/cmd/cyphernetes/root.go
+++ b/cmd/cyphernetes/root.go
@@ -44,8 +44,6 @@ func TestExecute(args []string) error {
 }
 
 func init() {
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cyphernetes.yaml)")
-
 	rootCmd.PersistentFlags().StringVarP(&parser.Namespace, "namespace", "n", "default", "The namespace to query against")
 	rootCmd.PersistentFlags().StringVarP(&parser.LogLevel, "loglevel", "l", "info", "The log level to use (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().BoolVarP(&parser.AllNamespaces, "all-namespaces", "A", false, "Query all namespaces")

--- a/cmd/cyphernetes/shell-autocomplete.go
+++ b/cmd/cyphernetes/shell-autocomplete.go
@@ -14,12 +14,7 @@ var resourceTreeStructureCache = make(map[string][]string)
 var resourceSpecs = make(map[string][]string)
 
 func initResourceSpecs() {
-	specs, err := parser.GetOpenAPIResourceSpecs()
-	if err != nil {
-		fmt.Println("Error fetching resource specs:", err)
-		return
-	}
-	resourceSpecs = specs
+	resourceSpecs = parser.ResourceSpecs
 }
 
 type CyphernetesCompleter struct {

--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -216,13 +216,22 @@ func runShell(cmd *cobra.Command, args []string) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
-	fmt.Println("Cyphernetes Interactive Shell")
-	fmt.Println("Type 'exit' or press Ctrl-D to exit")
-	fmt.Println("Type 'help' for information on how to use the shell")
+	fmt.Println(`
+                __                    __        
+ ______ _____  / /  ___ _______  ___ / /____ ___
+/ __/ // / _ \/ _ \/ -_) __/ _ \/ -_) __/ -_|_-<
+\__/\_, / .__/_//_/\__/_/ /_//_/\__/\__/\__/___/
+   /___/_/ Interactive Shell`)
+	fmt.Println("")
 	// Initialize the GRV cache
 	parser.FetchAndCacheGVRs(executor.Clientset)
+	parser.InitResourceSpecs()
 	initResourceSpecs()
 
+	fmt.Println("")
+	fmt.Println("Type 'exit' or press Ctrl-D to exit")
+	fmt.Println("Type 'help' for information on how to use the shell")
+	fmt.Println("")
 	var cmds []string
 	var input string
 	executing := false

--- a/pkg/parser/k8s_client.go
+++ b/pkg/parser/k8s_client.go
@@ -566,26 +566,34 @@ func extractKindFromSchemaName(schemaName string) string {
 
 func createRelationshipRule(parent string, schemaName string, path string) {
 	// first check if the relationship between the 2 kinds already exists
-	rule, err := findRuleByKinds(parent, schemaName)
+	rule, err := findRuleByKinds(schemaName, parent)
+	fieldA := "$." + path + ".metadata.name"
+	fieldB := "$.metadata.name"
+	kindA := schemaName
+	kindB := parent
 	if err != nil {
 		relationshipRule := RelationshipRule{
-			KindA:        parent,
-			KindB:        schemaName,
-			Relationship: RelationshipType(fmt.Sprintf("%s_REFERENCES_%s", parent, schemaName)),
+			KindA:        kindA,
+			KindB:        kindB,
+			Relationship: RelationshipType(fmt.Sprintf("%s_REFERENCES_%s", kindB, kindA)),
 			MatchCriteria: []MatchCriterion{
 				{
-					FieldA:         "$." + path + ".metadata.name",
-					FieldB:         "$.metadata.name",
+					FieldA:         fieldA,
+					FieldB:         fieldB,
 					ComparisonType: ExactMatch,
 				},
 			},
 		}
-		fmt.Printf("Creating relationship rule: %v\n", relationshipRule)
 		relationshipRules = append(relationshipRules, relationshipRule)
 	} else if len(rule.MatchCriteria) > 0 {
+		if rule.KindA == kindB && rule.KindB == kindA {
+			fieldA = "$.metadata.name"
+			fieldB = "$." + path + ".metadata.name"
+		}
+
 		rule.MatchCriteria = append(rule.MatchCriteria, MatchCriterion{
-			FieldA:         "$." + path + ".metadata.name",
-			FieldB:         "$.metadata.name",
+			FieldA:         fieldA,
+			FieldB:         fieldB,
 			ComparisonType: ExactMatch,
 		})
 	}

--- a/pkg/parser/k8s_client.go
+++ b/pkg/parser/k8s_client.go
@@ -574,7 +574,7 @@ func createRelationshipRule(parent string, schemaName string, path string) {
 			Relationship: RelationshipType(fmt.Sprintf("%s_REFERENCES_%s", parent, schemaName)),
 			MatchCriteria: []MatchCriterion{
 				{
-					FieldA:         "$." + path + ".name",
+					FieldA:         "$." + path + ".metadata.name",
 					FieldB:         "$.metadata.name",
 					ComparisonType: ExactMatch,
 				},
@@ -584,7 +584,7 @@ func createRelationshipRule(parent string, schemaName string, path string) {
 		relationshipRules = append(relationshipRules, relationshipRule)
 	} else if len(rule.MatchCriteria) > 0 {
 		rule.MatchCriteria = append(rule.MatchCriteria, MatchCriterion{
-			FieldA:         "$." + path + ".name",
+			FieldA:         "$." + path + ".metadata.name",
 			FieldB:         "$.metadata.name",
 			ComparisonType: ExactMatch,
 		})

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -10,6 +10,7 @@ import (
 var Namespace string
 var LogLevel string
 var AllNamespaces bool
+var CleanOutput bool
 
 type Expression struct {
 	Clauses []Clause

--- a/pkg/parser/relationship.go
+++ b/pkg/parser/relationship.go
@@ -79,7 +79,6 @@ func initializeRelationships() {
 								},
 							},
 						}
-						fmt.Println("*** Creating relationship rule: ", rule)
 					}
 
 					// Append the new rule to existing relationshipRules

--- a/pkg/parser/relationship.go
+++ b/pkg/parser/relationship.go
@@ -65,7 +65,6 @@ func initializeRelationships() {
 							FieldB:         "$.metadata.name",
 							ComparisonType: ExactMatch,
 						})
-						fmt.Println("*** Appending to existing relationship rule: ", rule)
 					} else {
 						rule = RelationshipRule{
 							KindA:        strings.ToLower(kindAName),

--- a/pkg/parser/relationship.go
+++ b/pkg/parser/relationship.go
@@ -72,26 +72,33 @@ func initializeRelationships() {
 				// If it does exist, append the new criterion to the existing rule's match criteria.
 				relType := RelationshipType(fmt.Sprintf("%s%s_INSPEC_%s", strings.ToUpper(relatedKindSingular), strings.ToUpper(relSpecType), strings.ToUpper(kindANameSingular)))
 				rule, err := findRuleByKinds(strings.ToLower(kindAName), strings.ToLower(relatedKind))
+				kindA = strings.ToLower(kindAName)
+				kindB := strings.ToLower(relatedKind)
+				fieldA := "$." + fieldPath
+				fieldB := "$.metadata.name"
 				if err == nil {
+					if rule.KindA == kindB && rule.KindB == kindA {
+						fieldA = "$.metadata.name"
+						fieldB = "$." + fieldPath
+					}
 					rule.MatchCriteria = append(rule.MatchCriteria, MatchCriterion{
-						FieldA:         "$." + fieldPath,
-						FieldB:         "$.metadata.name",
+						FieldA:         fieldA,
+						FieldB:         fieldB,
 						ComparisonType: ExactMatch,
 					})
 				} else {
 					rule = RelationshipRule{
-						KindA:        strings.ToLower(kindAName),
-						KindB:        strings.ToLower(relatedKind),
+						KindA:        kindA,
+						KindB:        kindB,
 						Relationship: relType,
 						MatchCriteria: []MatchCriterion{
 							{
-								FieldA:         "$." + fieldPath,
-								FieldB:         "$.metadata.name",
+								FieldA:         fieldA,
+								FieldB:         fieldB,
 								ComparisonType: ExactMatch,
 							},
 						},
 					}
-
 					// Append the new rule to existing relationshipRules
 					relationshipRules = append(relationshipRules, rule)
 				}
@@ -111,7 +118,7 @@ func findRuleByRelationshipType(relationshipType RelationshipType) (Relationship
 
 func findRuleByKinds(kindA, kindB string) (RelationshipRule, error) {
 	for _, rule := range relationshipRules {
-		if rule.KindA == kindA && rule.KindB == kindB {
+		if (rule.KindA == kindA && rule.KindB == kindB) || (rule.KindA == kindB && rule.KindB == kindA) {
 			return rule, nil
 		}
 	}

--- a/pkg/parser/relationship_types.go
+++ b/pkg/parser/relationship_types.go
@@ -9,37 +9,27 @@ type ResourceRelationship struct {
 type RelationshipType string
 
 const (
-	DeploymentOwnReplicaset                RelationshipType = "DEPLOYMENT_OWN_REPLICASET"
-	ReplicasetOwnPod                       RelationshipType = "REPLICASET_OWN_POD"
-	StatefulsetOwnPod                      RelationshipType = "STATEFULSET_OWN_POD"
-	DaemonsetOwnPod                        RelationshipType = "DAEMONSET_OWN_POD"
-	JobOwnPod                              RelationshipType = "JOB_OWN_POD"
-	ServiceExposePod                       RelationshipType = "SERVICE_EXPOSE_POD"
-	ServiceExposeDeployment                RelationshipType = "SERVICE_EXPOSE_DEPLOYMENT"
-	ServiceExposeStatefulset               RelationshipType = "SERVICE_EXPOSE_STATEFULSET"
-	ServiceExposeDaemonset                 RelationshipType = "SERVICE_EXPOSE_DAEMONSET"
-	ServiceExposeReplicaset                RelationshipType = "SERVICE_EXPOSE_REPLICASET"
-	CronJobOwnPod                          RelationshipType = "CRONJOB_OWN_POD"
-	CronJobOwnJob                          RelationshipType = "CRONJOB_OWN_JOB"
-	PVBoundPVC                             RelationshipType = "PV_BOUND_PVC"
-	ServiceHasEndpoints                    RelationshipType = "SERVICE_HAS_ENDPOINTS"
-	PodUseConfigMap                        RelationshipType = "POD_USE_CONFIGMAP"
-	PodUseSecret                           RelationshipType = "POD_USE_SECRET"
-	NetworkPolicyApplyPod                  RelationshipType = "NETWORKPOLICY_APPLY_POD"
-	HPAScaleDeployment                     RelationshipType = "HPA_SCALE_DEPLOYMENT"
-	NodeRunPod                             RelationshipType = "NODE_RUN_POD"
-	PodUseServiceAccount                   RelationshipType = "POD_USE_SERVICEACCOUNT"
-	RoleBindingReferenceRole               RelationshipType = "ROLEBINDING_REFERENCE_ROLE"
-	ClusterRoleBindingReferenceClusterRole RelationshipType = "CLUSTERROLEBINDING_REFERENCE_CLUSTERROLE"
-	PVCUseStorageClass                     RelationshipType = "PVC_USE_STORAGECLASS"
-	MutatingWebhookTargetService           RelationshipType = "MUTATINGWEBHOOK_TARGET_SERVICE"
-	ValidatingWebhookTargetService         RelationshipType = "VALIDATINGWEBHOOK_TARGET_SERVICE"
-	PDBProtectPod                          RelationshipType = "PDB_PROTECT_POD"
+	DeploymentOwnReplicaset        RelationshipType = "DEPLOYMENT_OWN_REPLICASET"
+	ReplicasetOwnPod               RelationshipType = "REPLICASET_OWN_POD"
+	StatefulsetOwnPod              RelationshipType = "STATEFULSET_OWN_POD"
+	DaemonsetOwnPod                RelationshipType = "DAEMONSET_OWN_POD"
+	JobOwnPod                      RelationshipType = "JOB_OWN_POD"
+	ServiceExposePod               RelationshipType = "SERVICE_EXPOSE_POD"
+	ServiceExposeDeployment        RelationshipType = "SERVICE_EXPOSE_DEPLOYMENT"
+	ServiceExposeStatefulset       RelationshipType = "SERVICE_EXPOSE_STATEFULSET"
+	ServiceExposeDaemonset         RelationshipType = "SERVICE_EXPOSE_DAEMONSET"
+	ServiceExposeReplicaset        RelationshipType = "SERVICE_EXPOSE_REPLICASET"
+	CronJobOwnPod                  RelationshipType = "CRONJOB_OWN_POD"
+	CronJobOwnJob                  RelationshipType = "CRONJOB_OWN_JOB"
+	ServiceHasEndpoints            RelationshipType = "SERVICE_HAS_ENDPOINTS"
+	NetworkPolicyApplyPod          RelationshipType = "NETWORKPOLICY_APPLY_POD"
+	HPAScaleDeployment             RelationshipType = "HPA_SCALE_DEPLOYMENT"
+	RoleBindingReferenceRole       RelationshipType = "ROLEBINDING_REFERENCE_ROLE"
+	MutatingWebhookTargetService   RelationshipType = "MUTATINGWEBHOOK_TARGET_SERVICE"
+	ValidatingWebhookTargetService RelationshipType = "VALIDATINGWEBHOOK_TARGET_SERVICE"
+	PDBProtectPod                  RelationshipType = "PDB_PROTECT_POD"
 	// ingresses to services
 	Route RelationshipType = "ROUTE"
-
-	// This is for configMaps, Volumes, Secrets in pods
-	Mount RelationshipType = "MOUNT"
 
 	// special relationships
 	NamespaceHasResource RelationshipType = "NAMESPACE_HAS_RESOURCE"
@@ -123,18 +113,6 @@ var relationshipRules = []RelationshipRule{
 		},
 	},
 	{
-		KindA:        "persistentvolumeclaims",
-		KindB:        "persistentvolumes",
-		Relationship: PVBoundPVC,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.spec.volumeName",
-				FieldB:         "$.metadata.name",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
 		KindA:        "endpoints",
 		KindB:        "services",
 		Relationship: ServiceHasEndpoints,
@@ -142,30 +120,6 @@ var relationshipRules = []RelationshipRule{
 			{
 				FieldA:         "$.metadata.name",
 				FieldB:         "$.metadata.name",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
-		KindA:        "configmaps",
-		KindB:        "pods",
-		Relationship: PodUseConfigMap,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.metadata.name",
-				FieldB:         "$.spec.volumes[].configMap.name",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
-		KindA:        "secrets",
-		KindB:        "pods",
-		Relationship: PodUseSecret,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.metadata.name",
-				FieldB:         "$.spec.volumes[].secret.secretName",
 				ComparisonType: ExactMatch,
 			},
 		},
@@ -351,66 +305,6 @@ var relationshipRules = []RelationshipRule{
 					},
 				},
 				ComparisonType: ContainsAll,
-			},
-		},
-	},
-	{
-		KindA:        "pods",
-		KindB:        "nodes",
-		Relationship: NodeRunPod,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.spec.nodeName",
-				FieldB:         "$.metadata.name",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
-		KindA:        "serviceaccounts",
-		KindB:        "pods",
-		Relationship: PodUseServiceAccount,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.metadata.name",
-				FieldB:         "$.spec.serviceAccountName",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
-		KindA:        "roles",
-		KindB:        "rolebindings",
-		Relationship: RoleBindingReferenceRole,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.metadata.name",
-				FieldB:         "$.roleRef.name",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
-		KindA:        "clusterroles",
-		KindB:        "clusterrolebindings",
-		Relationship: ClusterRoleBindingReferenceClusterRole,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.metadata.name",
-				FieldB:         "$.roleRef.name",
-				ComparisonType: ExactMatch,
-			},
-		},
-	},
-	{
-		KindA:        "storageclasses",
-		KindB:        "persistentvolumeclaims",
-		Relationship: PVCUseStorageClass,
-		MatchCriteria: []MatchCriterion{
-			{
-				FieldA:         "$.metadata.name",
-				FieldB:         "$.spec.storageClassName",
-				ComparisonType: ExactMatch,
 			},
 		},
 	},

--- a/pkg/parser/relationship_types.go
+++ b/pkg/parser/relationship_types.go
@@ -74,7 +74,6 @@ type RelationshipRule struct {
 }
 
 var relationshipRules = []RelationshipRule{
-
 	{
 		KindA:        "pods",
 		KindB:        "replicasets",
@@ -464,5 +463,4 @@ var relationshipRules = []RelationshipRule{
 			},
 		},
 	},
-	// Add more rules here...
 }


### PR DESCRIPTION
After scanning the openAPI document, we can now infer many relationships automatically from field names ending with either `Name`, `Ref`, or `KeyRef`.
The PR removes such relationships that were hardcoded before, as well as several broken hardcoded relationships.

We now also discover relationships by references while traversing the cluster's openapi document.