### PR TITLE
[ISSUE-102] Add support SUM on CPU and Memory

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -526,6 +526,22 @@ RETURN COUNT{p} AS TotalPods,
 }
 ```
 
+```graphql
+MATCH (d:deployment {name:"auth-service"})->(s:svc)->(p:pod) 
+RETURN SUM { p.spec.containers[*].resources.requests.cpu } AS totalCPUReq, 
+       SUM {p.spec.containers[*].resources.requests.memory } AS totalMemReq;
+
+
+{
+  ...
+  "aggregate": {
+    "totalCPUReq": "5",
+    "totalMemReq": "336.0Mi"
+  },
+  ...
+}
+```
+
 ## Macros
 
 Cyphernetes comes with a set of default macros that can be used to query the Kubernetes API.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -524,3 +524,19 @@ RETURN COUNT{p} AS TotalPods,
   ...
 }
 ```
+
+```graphql
+MATCH (d:deployment {name:"auth-service"})->(s:svc)->(p:pod) 
+RETURN SUM { p.spec.containers[*].resources.requests.cpu } AS totalCPUReq, 
+       SUM {p.spec.containers[*].resources.requests.memory } AS totalMemReq;
+
+
+{
+  ...
+  "aggregate": {
+    "totalCPUReq": "5",
+    "totalMemReq": "336.0Mi"
+  },
+  ...
+}
+```

--- a/pkg/parser/k8s_query.go
+++ b/pkg/parser/k8s_query.go
@@ -546,6 +546,12 @@ func (q *QueryExecutor) Execute(ast *Expression, namespace string) (QueryResult,
 					if key == "" {
 						key = strings.ToLower(item.Aggregate) + ":" + nodeId + "." + strings.Replace(pathStr, "$.", "", 1)
 					}
+
+					if slice, ok := aggregateResult.([]interface{}); ok && len(slice) == 0 {
+						aggregateResult = nil
+					} else if strSlice, ok := aggregateResult.([]string); ok && len(strSlice) == 1 {
+						aggregateResult = strSlice[0]
+					}
 					aggregateMap[key] = aggregateResult
 				}
 			}

--- a/pkg/parser/k8s_query.go
+++ b/pkg/parser/k8s_query.go
@@ -457,7 +457,7 @@ func (q *QueryExecutor) Execute(ast *Expression, namespace string) (QueryResult,
 										}
 
 										// SUM the CPU values and add the "m" suffix to indicate milliCPU
-										aggregateResult = strconv.Itoa(v1_cpu+v2_cpu) + "m"
+										aggregateResult = convertMilliCPUToStandard(v1_cpu + v2_cpu)
 
 									} else if strings.Contains(pathStr, "resources.limits.memory") || strings.Contains(pathStr, "resources.requests.memory") {
 										v1_mem, err := convertMemoryToBytes(v1.String())
@@ -1286,6 +1286,27 @@ func convertToMilliCPU(cpu string) (int, error) {
 	}
 
 	return standardCPU * 1000, nil
+}
+
+// convertMilliCPUToStandard converts a CPU value in milliCPU to the standard notation (integer or float)
+// if it's more readable. If it's less than 1000m, it returns the value in milliCPU format.
+func convertMilliCPUToStandard(milliCPU int) string {
+	// If the value is 1000m or greater, convert to standard CPU notation
+	if milliCPU >= 1000 {
+		// Convert to standard CPU by dividing by 1000 and check for decimal points
+		standardCPU := float64(milliCPU) / 1000.0
+
+		// If the value is a whole number (e.g., 2000m becomes 2), format as an integer
+		if standardCPU == float64(int(standardCPU)) {
+			return strconv.Itoa(int(standardCPU))
+		}
+
+		// Otherwise, return as a float with one decimal place
+		return fmt.Sprintf("%.1f", standardCPU)
+	}
+
+	// If less than 1000m, return the value in milliCPU format with the "m" suffix
+	return strconv.Itoa(milliCPU) + "m"
 }
 
 // convertMemoryToBytes takes a memory string like "500M" or "2Gi"

--- a/pkg/parser/k8s_query_test.go
+++ b/pkg/parser/k8s_query_test.go
@@ -1,8 +1,9 @@
-package parser_test
+package parser
 
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/AvitalTamir/jsonpath"
@@ -239,5 +240,244 @@ func TestJsonPath(t *testing.T) {
 			fmt.Println("Error executing jsonpath: ", err)
 			t.Fail()
 		}
+	}
+}
+
+func TestConvertToMilliCPU(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+		wantErr  bool
+	}{
+		{"Valid milliCPU", "100m", 100, false},
+		{"Valid standard CPU", "1", 1000, false},
+		{"Valid standard CPU", "2", 2000, false},
+		{"Valid standard CPU", "1.5", 1500, false},
+		{"Valid standard CPU", "3.7", 3700, false},
+		{"Valid standard CPU", "0.1", 100, false},
+		{"Valid standard CPU", "1.234", 1234, false},
+		{"Valid standard CPU", "0.001", 1, false},
+		{"Invalid milliCPU", "100x", 0, true},
+		{"invalid format", "abc", 0, true},
+		{"Zero milliCPU", "0m", 0, false},
+		{"Zero standard CPU", "0", 0, false},
+		{"Empty string", "", 0, true},
+		{"milliCPU format", "500m", 500, false},
+		{"milliCPU format", "1000m", 1000, false},
+		{"large number in standard CPU", "100", 100000, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertToMilliCPU(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertToMilliCPU() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("convertToMilliCPU() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertMilliCPUToStandard(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{"Less than 1000m", 500, "500m"},
+		{"Exactly 1000m", 1000, "1"},
+		{"More than 1000m, whole number", 2000, "2"},
+		{"More than 1000m, decimal", 1500, "1.5"},
+		{"Large number", 5678, "5.678"},
+		{"Large number", 12340, "12.34"},
+		{"Zero", 0, "0m"},
+		{"Very small number", 1, "1m"},
+		{"Very large number", 10000, "10"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertMilliCPUToStandard(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertMilliCPUToStandard(%d) = %s; want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertMemoryToBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+		wantErr  bool
+	}{
+		{"Exabyte", "1E", 1e18, false},
+		{"Petabyte", "1P", 1e15, false},
+		{"Terabyte", "1T", 1e12, false},
+		{"Gigabyte", "1G", 1e9, false},
+		{"Megabyte", "1M", 1e6, false},
+		{"Kilobyte", "1k", 1e3, false},
+		{"Exbibyte", "1Ei", 1 << 60, false},
+		{"Pebibyte", "1Pi", 1 << 50, false},
+		{"Tebibyte", "1Ti", 1 << 40, false},
+		{"Gibibyte", "1Gi", 1 << 30, false},
+		{"Mebibyte", "1Mi", 1 << 20, false},
+		{"Kibibyte", "1Ki", 1 << 10, false},
+		{"Bytes", "1000", 1000, false},
+		{"Invalid", "1X", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertMemoryToBytes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertMemoryToBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("convertMemoryToBytes() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertBytesToMemory(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int64
+		expected string
+	}{
+		// Binary (power-of-two) units
+		{"Exbibyte", 1 << 60, "1.0Ei"},
+		{"Pebibyte", 1 << 50, "1.0Pi"},
+		{"Tebibyte", 1 << 40, "1.0Ti"},
+		{"Gibibyte", 1 << 30, "1.0Gi"},
+		{"Mebibyte", 1 << 20, "1.0Mi"},
+		{"Kibibyte", 1 << 10, "1.0Ki"},
+		{"Exabyte", 1e18, "1.0E"},
+		{"Petabyte", 1e15, "1.0P"},
+		{"Terabyte", 1e12, "1.0T"},
+		{"Gigabyte", 1e9, "1.0G"},
+		{"Megabyte", 1e6, "1.0M"},
+		{"Kilobyte", 1e3, "1.0k"},
+		{"Zero bytes", 0, "0"},
+		{"One byte", 1, "1"},
+		{"999 bytes", 999, "999"},
+		{"1.5 Gibibytes", 1610612736, "1.5Gi"},
+		{"1.5 Mebibytes", 1572864, "1.5Mi"},
+		{"1.5 Kibibytes", 1536, "1.5Ki"},
+		{"Large binary", 1125899906842624, "1.0Pi"},
+		{"Large decimal", 1000000000000000, "1.0P"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertBytesToMemory(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertBytesToMemory(%d) = %s; want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertToStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    reflect.Value
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "String slice",
+			input:    reflect.ValueOf([]string{"a", "b", "c"}),
+			expected: []string{"a", "b", "c"},
+			wantErr:  false,
+		},
+		{
+			name:     "Int slice",
+			input:    reflect.ValueOf([]int{1, 2, 3}),
+			expected: []string{"1", "2", "3"},
+			wantErr:  false,
+		},
+		{
+			name:     "Not a slice",
+			input:    reflect.ValueOf("not a slice"),
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertToStringSlice(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertToStringSlice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("convertToStringSlice() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSumMilliCPU(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected int
+		wantErr  bool
+	}{
+		{"Valid milliCPU", []string{"100m", "200m", "300m"}, 600, false},
+		{"Valid standard CPU", []string{"1", "2", "3"}, 6000, false},
+		{"Mixed formats", []string{"1", "2000m", "3"}, 6000, false},
+		{"Invalid input", []string{"1", "2", "invalid"}, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sumMilliCPU(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sumMilliCPU() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("sumMilliCPU() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSumMemoryBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected int64
+		wantErr  bool
+	}{
+		{"Valid memory units", []string{"1Gi", "2Mi", "3Ki"}, 1075842048, false},
+		{"Mixed units 1", []string{"1G", "2M", "3k"}, 1002003000, false},
+		{"Mixed units 2", []string{"1Ei", "2Ti", "3Mi", "1P", "2G", "3k"}, 1153923705633251256, false},
+		{"Mixed units 3", []string{"1Pi", "2Gi", "3Ki", "1E", "2T", "3M"}, 1001127902057329344, false},
+		{"Bytes", []string{"1000", "2000", "3000"}, 6000, false},
+		{"Invalid input", []string{"1Gi", "2Mi", "invalid", "5K"}, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sumMemoryBytes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sumMemoryBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("sumMemoryBytes() = %v, want %v", got, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Resolves #102 

Changes made in this PR:
1. Implement logic for adding support SUM on CPU and Memory resources
2. Implement helper functions such as `convertToMilliCPU()`, `convertMilliCPUToStandard`, `convertMemoryToBytes`, `convertBytesToMemory` for handling string and int manipulation for summing K8 CPU and Memory values ( which needs unit conversion ).
3. add unit tests
4. add SUM cpu and memory query example in docs

Notes:
1. Manually tested with `cyphernetes shell -A`, trying these commands:
```
MATCH (p:Pod) RETURN SUM{p.spec.containers[0].resources.limits.cpu};
MATCH (p:Pod) RETURN SUM{p.spec.containers[0].resources.requests.cpu};
MATCH (p:Pod) RETURN SUM{p.spec.containers[0].resources.limits.memory};
MATCH (p:Pod) RETURN SUM{p.spec.containers[0].resources.requests.memory};

MATCH (p:Pod) RETURN SUM{p.spec.containers[*].resources.limits.cpu};
MATCH (p:Pod) RETURN SUM{p.spec.containers[*].resources.requests.cpu};
MATCH (p:Pod) RETURN SUM{p.spec.containers[*].resources.limits.memory};
MATCH (p:Pod) RETURN SUM{p.spec.containers[*].resources.requests.memory};
```
and compared the summed values with `kube-capacity --pods` ( https://github.com/robscott/kube-capacity ) 
