### PR TITLE
Support custom relationships

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -100,7 +100,7 @@ cyphernetes query 'MATCH (d:Deployment {name: "nginx"}) RETURN d'
 
 # Custom Relationships
 
-Cyphernetes allows you to define custom relationships between Kubernetes resources in a `~/.cyphernetes/relationships.yaml` file. This is useful when working with custom resources or when you want to define relationships that aren't built into Cyphernetes.
+Cyphernetes allows defining custom relationships between Kubernetes resources in a `~/.cyphernetes/relationships.yaml` file. This is useful when working with custom resources or when you want to define relationships that aren't built into Cyphernetes.
 
 Example relationships.yaml:
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -145,6 +145,6 @@ The relationships.yaml file supports the following fields:
 Custom relationships are loaded on startup and can be used just like built-in relationships in queries:
 
 ```graphql
-MATCH (d:Deployment)->(c:ConfigMap)
-RETURN d.metadata.name, c.metadata.name
+MATCH (d:Deployment)->(p:Pod)
+RETURN d.metadata.name, p.metadata.name
 ```

--- a/pkg/parser/k8s_client.go
+++ b/pkg/parser/k8s_client.go
@@ -359,7 +359,7 @@ func GetOpenAPIResourceSpecs() (map[string][]string, error) {
 // fetchResourceSpecsFromOpenAPI fetches and parses the OpenAPI V3 schemas
 func fetchResourceSpecsFromOpenAPI() (map[string][]string, error) {
 	if !CleanOutput {
-		fmt.Print("🔎 fetching resource specs from openapi... ")
+		fmt.Print("🔎 fetching resource specs... ")
 	}
 	openAPIDocMutex.Lock()
 	defer openAPIDocMutex.Unlock()

--- a/pkg/parser/relationship_types.go
+++ b/pkg/parser/relationship_types.go
@@ -38,29 +38,29 @@ const (
 type ComparisonType string
 
 const (
-	ExactMatch  ComparisonType = "ExactMatch"
-	ContainsAll ComparisonType = "ContainsAll"
+	ExactMatch     ComparisonType = "ExactMatch"
+	ContainsAll    ComparisonType = "ContainsAll"
+	StringContains ComparisonType = "StringContains"
 )
 
 type MatchCriterion struct {
-	FieldA         string
-	FieldB         string
-	ComparisonType ComparisonType
-	DefaultProps   []DefaultProp
+	FieldA         string         `yaml:"fieldA"`
+	FieldB         string         `yaml:"fieldB"`
+	ComparisonType ComparisonType `yaml:"comparisonType"`
+	DefaultProps   []DefaultProp  `yaml:"defaultProps,omitempty"`
 }
 
 type DefaultProp struct {
-	FieldA  string
-	FieldB  string
-	Default interface{}
+	FieldA  string      `yaml:"fieldA"`
+	FieldB  string      `yaml:"fieldB"`
+	Default interface{} `yaml:"default"`
 }
 
 type RelationshipRule struct {
-	KindA        string
-	KindB        string
-	Relationship RelationshipType
-	// Currently only supports one match criterion but can be extended to support multiple
-	MatchCriteria []MatchCriterion
+	KindA         string           `yaml:"kindA"`
+	KindB         string           `yaml:"kindB"`
+	Relationship  RelationshipType `yaml:"relationship"`
+	MatchCriteria []MatchCriterion `yaml:"matchCriteria"`
 }
 
 var relationshipRules = []RelationshipRule{


### PR DESCRIPTION
Allows defining custom relationships between Kubernetes resources in a `~/.cyphernetes/relationships.yaml` file. This is useful when working with custom resources or when you want to define relationships that aren't built into Cyphernetes.

Example relationships.yaml:

```yaml
relationships:
  - kindA: applications.argoproj.io
    kindB: services
    relationship: ARGOAPP_SYNC_SERVICE
    matchCriteria:
      - fieldA: "$.spec.source.targetRevision"
        fieldB: "$.metadata.labels.targetRevision"
        comparisonType: ExactMatch
      - fieldA: "$.spec.project"
        fieldB: "$.metadata.labels.project" 
        comparisonType: ExactMatch

  - kindA: pods
    kindB: deployments
    relationship: DEPLOYMENT_OWN_POD
    matchCriteria:
      - fieldA: "$.metadata.name"
        fieldB: "$.metadata.name"
        comparisonType: StringContains
```

The relationships.yaml file supports the following fields:

- `kindA`, `kindB`: The Kubernetes resource kinds to relate (use plural form, e.g. "deployments" not "Deployment")
- `relationship`: A unique identifier for this relationship type (conventionally UPPERCASE)
- `matchCriteria`: List of criteria that must all match for the relationship to exist
  - `fieldA`: JSONPath to field in kindA resource
  - `fieldB`: JSONPath to field in kindB resource  
  - `comparisonType`: One of:
    - `ExactMatch`: Values must match exactly
    - `ContainsAll`: All key-value pairs in fieldB must exist in fieldA
    - `StringContains`: The value in fieldA contains the value in fieldB as a substring
  - `defaultProps`: Optional default values to use when creating resources
    - `fieldA`: JSONPath to field in kindA
    - `fieldB`: JSONPath to field in kindB  
    - `default`: Default value if field is not specified

Custom relationships are loaded on startup and can be used just like built-in relationships in queries:

```graphql
MATCH (d:Deployment)->(p:Pod)
RETURN d.metadata.name, p.metadata.name
```
