### PR TITLE
fix(parser): support fully qualified kinds

### DIFF
--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -133,7 +133,7 @@ var (
 	keywordsRegex   = regexp.MustCompile(`(?i)\b(match|where|contains|set|delete|create|sum|count|as|in)\b`)
 	bracketsRegex   = regexp.MustCompile(`[\(\)\[\]\{\}\<\>]`)
 	variableRegex   = regexp.MustCompile(`"(.*?)"`)
-	identifierRegex = regexp.MustCompile(`0m(\w+):(\w+)`)
+	identifierRegex = regexp.MustCompile(`0m(\w+):([.\w]+)`)
 	propertiesRegex = regexp.MustCompile(`\{((?:[^{}]|\{[^{}]*\})*)\}`)
 	returnRegex     = regexp.MustCompile(`(?i)(return)(\s+.*)`)
 )

--- a/pkg/core/lexer_test.go
+++ b/pkg/core/lexer_test.go
@@ -140,6 +140,30 @@ func TestLexer(t *testing.T) {
 				{Type: EOF, Literal: ""},
 			},
 		},
+		{
+			name:  "fully qualified resource kinds",
+			input: "(d:deployments.apps), (p:pods.v1.core), (c:configmaps.v1)",
+			expected: []Token{
+				{Type: LPAREN, Literal: "("},
+				{Type: IDENT, Literal: "d"},
+				{Type: COLON, Literal: ":"},
+				{Type: IDENT, Literal: "deployments.apps"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: COMMA, Literal: ","},
+				{Type: LPAREN, Literal: "("},
+				{Type: IDENT, Literal: "p"},
+				{Type: COLON, Literal: ":"},
+				{Type: IDENT, Literal: "pods.v1.core"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: COMMA, Literal: ","},
+				{Type: LPAREN, Literal: "("},
+				{Type: IDENT, Literal: "c"},
+				{Type: COLON, Literal: ":"},
+				{Type: IDENT, Literal: "configmaps.v1"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: EOF, Literal: ""},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -874,6 +874,76 @@ func TestRecursiveParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "match with fully qualified resource kinds",
+			input: `MATCH (d:deployments.apps) RETURN d.spec.replicas`,
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "d",
+									Kind: "deployments.apps",
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "d.spec.replicas"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "match with multiple fully qualified resource kinds",
+			input: `MATCH (d:deployments.apps)->(p:pods.v1.core) RETURN d.metadata.name, p.metadata.name`,
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "d",
+									Kind: "deployments.apps",
+								},
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "p",
+									Kind: "pods.v1.core",
+								},
+							},
+						},
+						Relationships: []*Relationship{
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "d",
+										Kind: "deployments.apps",
+									},
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "p",
+										Kind: "pods.v1.core",
+									},
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "d.metadata.name"},
+							{JsonPath: "p.metadata.name"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provider/apiserver/provider.go
+++ b/pkg/provider/apiserver/provider.go
@@ -252,7 +252,8 @@ func (p *APIServerProvider) FindGVR(kind string) (schema.GroupVersionResource, e
 		if strings.ToLower(k) == lowerKind || // Case-insensitive kind match
 			strings.ToLower(gvr.Resource) == lowerKind || // Plural form
 			strings.ToLower(strings.TrimSuffix(gvr.Resource, "s")) == lowerKind || // Singular form
-			strings.ToLower(strings.TrimSuffix(gvr.Resource, "es")) == lowerKind { // Singular form
+			strings.ToLower(strings.TrimSuffix(gvr.Resource, "es")) == lowerKind || // Singular form
+			(strings.HasSuffix(gvr.Resource, "ies") && strings.ToLower(strings.TrimSuffix(gvr.Resource, "ies")+"y") == lowerKind) { // Handle -ies to -y conversion
 			key := fmt.Sprintf("%s/%s", gvr.Resource, gvr.Group)
 			uniqueGVRs[key] = gvr
 			if gvr.Group == "" {
@@ -281,31 +282,6 @@ func (p *APIServerProvider) FindGVR(kind string) (schema.GroupVersionResource, e
 
 	return schema.GroupVersionResource{}, fmt.Errorf("resource %q not found", kind)
 }
-
-// Add helper method to get short names for a GVR
-// func (p *APIServerProvider) getShortNames(gvr schema.GroupVersionResource) []string {
-// 	resources, err := p.clientset.Discovery().ServerResourcesForGroupVersion(gvr.GroupVersion().String())
-// 	if err != nil {
-// 		return nil
-// 	}
-
-// 	for _, r := range resources.APIResources {
-// 		if r.Name == gvr.Resource {
-// 			return r.ShortNames
-// 		}
-// 	}
-// 	return nil
-// }
-
-// // Helper function for case-insensitive string slice contains
-// func containsStringIgnoreCase(slice []string, str string) bool {
-// 	for _, item := range slice {
-// 		if strings.EqualFold(item, str) {
-// 			return true
-// 		}
-// 	}
-// 	return false
-// }
 
 // Implement other Provider interface methods...
 func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string) error {


### PR DESCRIPTION
This PR addresses the issue of ambiguity in kinds with more than 1 group.
Cyphernetes will now alert on ambiguity, show the available kinds and tell the user to choose one.

The parser and default provider now support looking resources up by fully qualified names.