### PR TITLE
fix(shell): parameter namespace is being ignored

### DIFF
--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -237,7 +237,7 @@ func initAndRunShell(_ *cobra.Command, _ []string) {
 	}
 
 	// Get current context
-	currentContext, currentNamespace, err := getCurrentContext()
+	currentContext, _, err := getCurrentContext()
 	if err != nil {
 		fmt.Println("Error getting current context:", err)
 		os.Exit(1)
@@ -248,8 +248,6 @@ func initAndRunShell(_ *cobra.Command, _ []string) {
 	if core.AllNamespaces {
 		core.Namespace = ""
 		core.AllNamespaces = false
-	} else if currentNamespace != "" {
-		core.Namespace = currentNamespace
 	}
 
 	// Load default macros


### PR DESCRIPTION
This PR addresses the issue reported on #159 where the parameter `namespace` is being ignored when the Kubernetes context is set via `kubectl config set-context`.

Tested with:
```
❯ kubectl config set-context --current --namespace=test                                                                                                                                    
Context "default" modified.

❯ ./dist/cyphernetes shell 
...
(default) test » 

❯ ./dist/cyphernetes shell --namespace default
...
(default) default » 

❯ kubectl config set-context --current --namespace=default                                                                                                                                  
Context "default" modified.

❯ ./dist/cyphernetes shell 
...
(default) default » 

❯ ./dist/cyphernetes shell --namespace test
...
(default) test » 

❯ ./dist/cyphernetes shell -A 
...
(default) ALL NAMESPACES »
```