### PR TITLE
fix(web): incorrect namespace displayed in UI

### DIFF
--- a/cmd/cyphernetes/api.go
+++ b/cmd/cyphernetes/api.go
@@ -175,14 +175,8 @@ func handleGetContext(c *gin.Context) {
 		return
 	}
 
-	// Get namespace from context
-	namespace := "default"
-	if context, exists := config.Contexts[currentContext]; exists && context.Namespace != "" {
-		namespace = context.Namespace
-	}
-
 	c.JSON(http.StatusOK, ContextInfo{
 		Context:   currentContext,
-		Namespace: namespace,
+		Namespace: core.Namespace,
 	})
 }


### PR DESCRIPTION
This PR addresses the issue #163 where an incorrect namespace is being displayed in the Web UI.

I have tested that:
 - Web UI now shows the correct namespace
 - Web UI query the right namespace
 - `query` functionality works as expected
 - `shell` functionality works as expected

---

Detailed tests:
```
❯ kubectl config set-context --current --namespace=test
Context "default" modified.

❯ kubectl config get-contexts
CURRENT   NAME      CLUSTER   AUTHINFO   NAMESPACE
*         default   default   default    test

❯ kubectl get deployments --namespace default
No resources found in default namespace.

❯ kubectl get deployments --namespace test
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
test2   1/1     1            1           47m

❯ ./dist/cyphernetes web

❯ curl -s 'http://localhost:8080/api/context' 
{"context":"default","namespace":"test"}%  

❯ curl -s 'http://localhost:8080/api/query' -d '{"query":"MATCH (d:deployment) RETURN d.name"}' | jq -r .result
{"d":[{"name":"test2"}]}

❯ ./dist/cyphernetes web --namespace default

❯ curl -s 'http://localhost:8080/api/context' 
{"context":"default","namespace":"default"}% 

❯ curl -s 'http://localhost:8080/api/query' -d '{"query":"MATCH (d:deployment) RETURN d.name"}' | jq -r .result
{"d":[]}

❯ ./dist/cyphernetes query "MATCH (d:deployment) RETURN d.name" 
...
"d": [
    {
      "name": "test2"
    }

❯ ./dist/cyphernetes query --namespace default "MATCH (d:deployment) RETURN d.name" 
...
{
  "d": []
}

❯ ./dist/cyphernetes shell
...
(default) test » MATCH (d:deployment) RETURN d.name;
...
  "d": [
    {
      "name": "test2"

❯ ./dist/cyphernetes shell --namespace default
...
(default) default » MATCH (d:deployment) RETURN d.name;

{
  "d": []
}
```