### PR TITLE
feat(cli): add format flag

### DIFF
--- a/cmd/cyphernetes/query.go
+++ b/cmd/cyphernetes/query.go
@@ -9,6 +9,7 @@ import (
 	"github.com/avitaltamir/cyphernetes/pkg/core"
 	"github.com/avitaltamir/cyphernetes/pkg/provider/apiserver"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -71,18 +72,25 @@ func runQuery(args []string, w io.Writer) {
 		return
 	}
 
-	// Print the results as pretty JSON.
-	json, err := json.MarshalIndent(results.Data, "", "  ")
+	// Marshal data based on the output format
+	var output []byte
+	if core.OutputFormat == "yaml" {
+		output, err = yaml.Marshal(results.Data)
+	} else { // core.OutputFormat == "json"
+		output, err = json.MarshalIndent(results.Data, "", "  ")
+		if !returnRawJsonOutput {
+			output = []byte(formatJson(string(output)))
+		}
+	}
+
+	// Handle marshalling errors
 	if err != nil {
 		fmt.Fprintln(w, "Error marshalling results: ", err)
 		return
 	}
-	if !returnRawJsonOutput {
-		json = []byte(formatJson(string(json)))
-	}
 
-	if string(json) != "{}" {
-		fmt.Fprintln(w, string(json))
+	if string(output) != "{}" {
+		fmt.Fprintln(w, string(output))
 	}
 }
 

--- a/cmd/cyphernetes/query_test.go
+++ b/cmd/cyphernetes/query_test.go
@@ -68,6 +68,22 @@ func TestRunQuery(t *testing.T) {
 `,
 		},
 		{
+			name: "Successful query in YAML format",
+			args: []string{"MATCH (n:Pod)"},
+			mockParseQuery: func(query string) (*core.Expression, error) {
+				return &core.Expression{}, nil
+			},
+			mockExecute: func(expr *core.Expression, namespace string) (core.QueryResult, error) {
+				core.OutputFormat = "yaml"
+				return core.QueryResult{
+					Data: map[string]interface{}{
+						"test": "data",
+					},
+				}, nil
+			},
+			wantOut: "test: data\n\n",
+		},
+		{
 			name: "Parse query error",
 			args: []string{"INVALID QUERY"},
 			mockParseQuery: func(query string) (*core.Expression, error) {

--- a/cmd/cyphernetes/root.go
+++ b/cmd/cyphernetes/root.go
@@ -78,16 +78,16 @@ func TestExecute(args []string) error {
 func init() {
 	// First set the log level
 	rootCmd.PersistentFlags().StringVarP(&LogLevel, "loglevel", "l", "info", "The log level to use (debug, info, warn, error, fatal, panic)")
-	// Add a PreRun hook to set LogLevel after flag parsing
-	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		LogLevel = cmd.Flag("loglevel").Value.String()
-		core.LogLevel = LogLevel
-	}
 
 	// Set output format for shell and query
 	rootCmd.PersistentFlags().StringVar(&core.OutputFormat, "format", "json", "Output format for shell and query results")
-	// Return an error if the format is incorrect
+
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// Set LogLevel after flag parsing
+		LogLevel = cmd.Flag("loglevel").Value.String()
+		core.LogLevel = LogLevel
+
+		// Return an error if the format is incorrect
 		f := cmd.Flag("format").Value.String()
 		if f != "yaml" && f != "json" {
 			return fmt.Errorf("Invalid value for --format: must be 'json' or 'yaml'")

--- a/cmd/cyphernetes/root.go
+++ b/cmd/cyphernetes/root.go
@@ -84,6 +84,17 @@ func init() {
 		core.LogLevel = LogLevel
 	}
 
+	// Set output format for shell and query
+	rootCmd.PersistentFlags().StringVar(&core.OutputFormat, "format", "json", "Output format for shell and query results")
+	// Return an error if the format is incorrect
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		f := cmd.Flag("format").Value.String()
+		if f != "yaml" && f != "json" {
+			return fmt.Errorf("Invalid value for --format: must be 'json' or 'yaml'")
+		}
+		return nil
+	}
+
 	rootCmd.PersistentFlags().StringVarP(&core.Namespace, "namespace", "n", "default", "The namespace to query against")
 	rootCmd.PersistentFlags().BoolVarP(&core.AllNamespaces, "all-namespaces", "A", false, "Query all namespaces")
 	rootCmd.PersistentFlags().BoolVar(&core.NoColor, "no-color", false, "Disable colored output in shell and query results")

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -51,6 +51,7 @@ type QueryExecutor struct {
 var (
 	Namespace     string
 	LogLevel      string
+	OutputFormat  string
 	AllNamespaces bool
 	CleanOutput   bool
 	NoColor       bool


### PR DESCRIPTION
This PR implements the feature described in #158

I added a `--format` flag as a way to choose the output format for query and shell commands. I added it as a global flag just like the `--no-color` flag.

![image](https://github.com/user-attachments/assets/82c49a2d-8837-4a78-b566-6567f51a9c08)

Also, I tried to look for a library to color yaml just like it's done with the json output but couldn't find any.
