### PR TITLE
Partial node patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="1219" alt="Screenshot 2024-10-15 at 0 03 00" src="https://github.com/user-attachments/assets/e3a36dcf-2add-44fb-8c8a-71225e0e026b">
+<img width="1219" alt="Screenshot 2025-01-28 at 15 20 25" src="https://github.com/user-attachments/assets/47dbea39-e563-4a14-89cd-0569964b2d0c" />
 
 ![Cyphernetes Logo (3 5 x 1 2 in)](https://github.com/user-attachments/assets/2e0a92ce-26a6-4918-bc07-3747c2fe1464)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="1219" alt="Screenshot 2025-01-28 at 15 20 25" src="https://github.com/user-attachments/assets/47dbea39-e563-4a14-89cd-0569964b2d0c" />
+<img width="1219" alt="Screenshot 2024-10-15 at 0 03 00" src="https://github.com/user-attachments/assets/e3a36dcf-2add-44fb-8c8a-71225e0e026b">
 
 ![Cyphernetes Logo (3 5 x 1 2 in)](https://github.com/user-attachments/assets/2e0a92ce-26a6-4918-bc07-3747c2fe1464)
 

--- a/cmd/cyphernetes/shell_test.go
+++ b/cmd/cyphernetes/shell_test.go
@@ -127,13 +127,13 @@ func TestSyntaxHighlighterPaint(t *testing.T) {
 	}{
 		{
 			name:     "Keywords",
-			input:    "MATCH (n:Node) WHERE n.property = 'value' RETURN n",
-			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[\x1b[33mn\x1b[0m:\x1b[94mNode\x1b[0m\x1b[37m)\x1b[0m \x1b[35mWHERE\x1b[0m n.property = 'value' \x1b[35mRETURN\x1b[0m\x1b[35m n\x1b[0m",
+			input:    `MATCH (n:Node) WHERE n.property = "value" RETURN n`,
+			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[0m\x1b[33mn\x1b[0m:\x1b[94mNode\x1b[0m\x1b[37m)\x1b[0m \x1b[35mWHERE\x1b[0m n.property = \"value\" \x1b[35mRETURN\x1b[0m\x1b[35m n\x1b[0m",
 		},
 		{
 			name:     "Properties",
-			input:    "MATCH (n:Node {key: \"value\"})",
-			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[\x1b[33mn\x1b[0m:\x1b[94mNode\x1b[0m \x1b[37m{\x1b[33mkey: \x1b[0m\x1b[36m\"value\"\x1b[0m}\x1b[0m\x1b[37m)\x1b[0m",
+			input:    `MATCH (n:Node {key: "value"})`,
+			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[0m\x1b[33mn\x1b[0m:\x1b[94mNode \x1b[37m{\x1b[0m\x1b[33mkey: \x1b[0m\x1b[36m\"value\"\x1b[0m\x1b[37m}\x1b[0m\x1b[0m\x1b[37m)\x1b[0m",
 		},
 		{
 			name:     "Return with JSONPath",
@@ -149,6 +149,21 @@ func TestSyntaxHighlighterPaint(t *testing.T) {
 			name:     "Return with JSONPath and asterisk",
 			input:    "RETURN n.*",
 			expected: "\x1b[35mRETURN\x1b[0m\x1b[35m n\x1b[0m.*",
+		},
+		{
+			name:     "Kindless node",
+			input:    "MATCH (:Pod) RETURN n",
+			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[0m:\x1b[94mPod\x1b[0m\x1b[37m)\x1b[0m \x1b[35mRETURN\x1b[0m\x1b[35m n\x1b[0m",
+		},
+		{
+			name:     "Anonymous node",
+			input:    "MATCH (pod) RETURN pod",
+			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[0m\x1b[33mpod\x1b[0m\x1b[37m)\x1b[0m \x1b[35mRETURN\x1b[0m\x1b[35m pod\x1b[0m",
+		},
+		{
+			name:     "Mixed nodes",
+			input:    "MATCH (pod)-[:EXPOSED_BY]->(:Service) RETURN pod",
+			expected: "\x1b[35mMATCH\x1b[0m \x1b[37m(\x1b[0m\x1b[33mpod\x1b[0m\x1b[37m)\x1b[0m-\x1b[37m[\x1b[0m\x1b[94m:EXPOSED_BY\x1b[0m\x1b[37m]\x1b[0m->\x1b[37m(\x1b[0m:\x1b[94mService\x1b[0m\x1b[37m)\x1b[0m \x1b[35mRETURN\x1b[0m\x1b[35m pod\x1b[0m",
 		},
 	}
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -452,10 +452,10 @@ RETURN x.kind
 
 This query will find and return all resources that have a relationship with the "nginx" deployment, such as ReplicaSets and Services. Cyphernetes will automatically expand this query to try all possible kinds that can have a relationship with a Deployment.
 
-Some things to consider when using kindless nodes:
-* While kindless nodes are a powerful feature, they should be used judiciously. Being explicit about the kinds of resources you're operating on makes queries more predictable and easier to understand.
-* Chaining two kindless nodes (e.g., `MATCH (x)->(y)`) is not supported as it would be ambiguous and potentially expensive to resolve. At least one node in a relationship must have a known kind.
-* Standalone kindless nodes (e.g., `MATCH (x)`) are not supported. Kindless nodes must be part of a relationship.
+> Some things to consider when using kindless nodes:
+> * While kindless nodes are a powerful feature, they should be used judiciously. Being explicit about the kinds of resources you're operating on makes queries more predictable and easier to understand.
+> * Chaining two kindless nodes (e.g., `MATCH (x)->(y)`) is not supported as it would be ambiguous and potentially expensive to resolve. At least one node in a relationship must have a known kind.
+> * Standalone kindless nodes (e.g., `MATCH (x)`) are not supported. Kindless nodes must be part of a relationship.
 
 ### Anonymous Nodes
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -26,13 +26,13 @@ Imagine a flow diagram, where each node represents a Kubernetes resource, and th
 
 This is Cyphernetes in a nutshell. You draw a diagram of the resources you want to work with, and Cyphernetes will translate it into the appropriate Kubernetes API calls.
 
-Nodes are almost never empty. They tend to look more like this:
+Nodes are usually not empty. They tend to look more like this:
 
 ```graphql
-(k:Kind)
+(p:Pod)
 ```
 
-This node contains a _variable_ (in this example it's called `k`), followed by a colon, followed by a _label_ (in our case, it's `Kind`).
+This node contains a _variable_ (in this example it's called `p`), followed by a colon, followed by a _label_ (in our case, it's `Pod`).
 
 We assign variable names to nodes so we can refer to them later in the query. Labels are used to specify the node's Kubernetes resource kind.
 
@@ -74,7 +74,6 @@ This query will match all Deployments in the current context, and return their n
   ]
 }
 ```
-
 Let's do one more:
 
 ```graphql
@@ -85,6 +84,7 @@ RETURN d.metadata.name,
 ```
 
 This query will match all Deployments in the current context, and return a custom payload containing the fields we asked for:
+
 
 ```json
 {

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -154,8 +154,8 @@ Cyphernetes supports querying multiple clusters using the `IN` keyword.
 
 ```graphql
 IN staging, production
-MATCH (d:Deployment {namespace: "kube-system"})
-RETURN d.metadata.name
+MATCH (d:Deployment {name: "coredns", namespace: "kube-system"})
+RETURN d.spec.replicas
 ```
 
 Cyphernetes will run the query for each context in the `IN` clause, and return the results in a single payload.
@@ -165,18 +165,18 @@ The results will be prefixed with the context name, followed by an underscore:
 {
   "staging_d": [
     {
-      "metadata": {
-        "name": "coredns"
-      },
-      "name": "coredns"
+      "name": "coredns",
+      "spec": {
+        "replicas": 2
+      }
     }
   ],
   "production_d": [
     {
-      "metadata": {
-        "name": "coredns"
-      },
-      "name": "coredns"
+      "name": "coredns",
+      "spec": {
+        "replicas": 2
+      }
     }
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/core/e2e/e2e_test.go
+++ b/pkg/core/e2e/e2e_test.go
@@ -2120,6 +2120,26 @@ var _ = Describe("Cyphernetes E2E", func() {
 		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
 	})
 
+	It("Should not allow standalone kindless nodes", func() {
+		By("Executing query with standalone kindless node")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Query with standalone kindless node
+		ast, err := core.ParseQuery(`
+			MATCH (x)
+			RETURN x
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = executor.Execute(ast, testNamespace)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("kindless nodes may only be used in a relationship"))
+	})
+
 	It("Should handle aggregations with kindless nodes correctly", func() {
 		By("Creating test deployments with different replica counts")
 		// Create first deployment with 4 replicas

--- a/pkg/core/e2e/e2e_test.go
+++ b/pkg/core/e2e/e2e_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,6 +36,20 @@ var _ = Describe("Cyphernetes E2E", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
+
+		// Clean up any leftover test resources
+		k8sClient.Delete(ctx, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-agg-1",
+				Namespace: testNamespace,
+			},
+		})
+		k8sClient.Delete(ctx, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-agg-2",
+				Namespace: testNamespace,
+			},
+		})
 	})
 
 	Context("Basic Query Operations", func() {
@@ -2103,6 +2118,163 @@ var _ = Describe("Cyphernetes E2E", func() {
 
 		By("Cleaning up")
 		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
+	})
+
+	It("Should handle aggregations with kindless nodes correctly", func() {
+		By("Creating test deployments with different replica counts")
+		// Create first deployment with 4 replicas
+		deployment1 := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-agg-1",
+				Namespace: testNamespace, // Use testNamespace instead of "default"
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32(4),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "test-deployment-agg-1",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "test-deployment-agg-1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, deployment1)).Should(Succeed())
+
+		// Create second deployment with 2 replicas
+		deployment2 := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-agg-2",
+				Namespace: testNamespace, // Use testNamespace instead of "default"
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32(2),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "test-deployment-agg-2",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "test-deployment-agg-2",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, deployment2)).Should(Succeed())
+
+		// Wait for both deployments to complete their rollout
+		for _, deployName := range []string{"test-deployment-agg-1", "test-deployment-agg-2"} {
+			Eventually(func() bool {
+				var deployment appsv1.Deployment
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Namespace: testNamespace,
+					Name:      deployName,
+				}, &deployment)
+				if err != nil {
+					return false
+				}
+				return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas &&
+					deployment.Status.Replicas == *deployment.Spec.Replicas
+			}, timeout*2, interval).Should(BeTrue(), fmt.Sprintf("Deployment %s should be ready", deployName))
+		}
+
+		// Wait for ReplicaSets to be created and have the correct number of replicas
+		Eventually(func() error {
+			rsList := &appsv1.ReplicaSetList{}
+			if err := k8sClient.List(ctx, rsList, client.InNamespace(testNamespace)); err != nil {
+				return err
+			}
+			if len(rsList.Items) < 2 {
+				return fmt.Errorf("waiting for ReplicaSets to be created, current count: %d", len(rsList.Items))
+			}
+			totalReplicas := 0
+			for _, rs := range rsList.Items {
+				if rs.Status.Replicas > 0 { // Only count active ReplicaSets
+					totalReplicas += int(rs.Status.Replicas)
+				}
+			}
+			if totalReplicas < 6 {
+				return fmt.Errorf("waiting for ReplicaSets to have correct replicas, current total: %d", totalReplicas)
+			}
+			return nil
+		}, timeout*2, interval).Should(Succeed())
+
+		// Wait for all pods to be created
+		Eventually(func() error {
+			pods := &corev1.PodList{}
+			if err := k8sClient.List(ctx, pods, client.InNamespace(testNamespace)); err != nil {
+				return err
+			}
+			if len(pods.Items) < 6 {
+				return fmt.Errorf("waiting for all pods to be created, current count: %d", len(pods.Items))
+			}
+			return nil
+		}, timeout*2, interval).Should(Succeed())
+
+		By("Executing query with kindless node and aggregation")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		query := `match (p:Pod)->(x)->(:Deployment) where x.spec.replicas > 1 return p.status.phase, sum{x.spec.replicas} as replicasSum`
+		ast, err := core.ParseQuery(query)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the aggregation results")
+		// Check the pods array
+		pods, ok := result.Data["p"].([]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(len(pods)).To(Equal(6)) // Should have 6 pods in total
+
+		// Check the replicaset array
+		replicaSets, ok := result.Data["x"].([]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(len(replicaSets)).To(Equal(2)) // Should have 2 ReplicaSets
+
+		// Check the aggregate sum
+		aggregate, ok := result.Data["aggregate"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(aggregate["replicasSum"]).To(Equal(float64(6))) // Total replicas should be 6 (4 + 2)
+
+		// Remove the pod phase check since we don't care about the running state
+		// Just verify we can access the phase
+		for _, pod := range pods {
+			podMap := pod.(map[string]interface{})
+			Expect(podMap["status"].(map[string]interface{})).To(HaveKey("phase"))
+		}
+
+		By("Cleaning up test resources")
+		Expect(k8sClient.Delete(ctx, deployment1)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, deployment2)).Should(Succeed())
 	})
 })
 

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -1009,9 +1009,7 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 								} else {
 									// For non-aliased aggregations, use the format <aggregate_type>_<node>_<path>
 									aliasPath := item.JsonPath
-									if strings.Contains(aliasPath, ".") {
-										aliasPath = strings.Replace(aliasPath, ".", "_", -1)
-									}
+									aliasPath = strings.Replace(aliasPath, ".", "_", -1)
 									returnItem = fmt.Sprintf("%s AS __exp__%s__%s_%s__%d", returnItem, aggType, aggType, aliasPath, j)
 								}
 							} else if item.Alias != "" {
@@ -1095,7 +1093,7 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 	query := strings.Join(queryParts, " ")
 
 	// Log the expanded query for debugging
-	fmt.Printf("Expanded query: %s\n", query)
+	debugLog("Expanded query: %s\n", query)
 
 	// Parse the expanded query into a new AST
 	newAst, err := ParseQuery(query)

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -915,7 +915,29 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 								default:
 									valueStr = fmt.Sprintf("%v", v)
 								}
-								whereParts = append(whereParts, fmt.Sprintf("%s.%s = %s", varName, propertyPath, valueStr))
+								// Map operator names to symbols
+								operator := filter.Operator
+								switch operator {
+								case "EQUALS":
+									operator = "="
+								case "NOT_EQUALS":
+									operator = "!="
+								case "GREATER_THAN":
+									operator = ">"
+								case "LESS_THAN":
+									operator = "<"
+								case "GREATER_THAN_EQUALS":
+									operator = ">="
+								case "LESS_THAN_EQUALS":
+									operator = "<="
+								case "REGEX_COMPARE":
+									operator = "=~"
+								case "CONTAINS":
+									operator = "CONTAINS"
+								case "":
+									operator = "="
+								}
+								whereParts = append(whereParts, fmt.Sprintf("%s.%s %s %s", varName, propertyPath, operator, valueStr))
 							}
 						} else {
 							// If the node is not kindless, just use it as is
@@ -927,7 +949,29 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 							default:
 								valueStr = fmt.Sprintf("%v", v)
 							}
-							whereParts = append(whereParts, fmt.Sprintf("%s.%s = %s", varName, propertyPath, valueStr))
+							// Map operator names to symbols
+							operator := filter.Operator
+							switch operator {
+							case "EQUALS":
+								operator = "="
+							case "NOT_EQUALS":
+								operator = "!="
+							case "GREATER_THAN":
+								operator = ">"
+							case "LESS_THAN":
+								operator = "<"
+							case "GREATER_THAN_EQUALS":
+								operator = ">="
+							case "LESS_THAN_EQUALS":
+								operator = "<="
+							case "REGEX_COMPARE":
+								operator = "=~"
+							case "CONTAINS":
+								operator = "CONTAINS"
+							case "":
+								operator = "="
+							}
+							whereParts = append(whereParts, fmt.Sprintf("%s.%s %s %s", varName, propertyPath, operator, valueStr))
 						}
 					}
 				}

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -802,6 +802,13 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 				}
 			}
 			relationships = append(relationships, matchClause.Relationships...)
+
+			// Check for kindless-to-kindless chains in relationships
+			for _, rel := range matchClause.Relationships {
+				if rel.LeftNode.ResourceProperties.Kind == "" && rel.RightNode.ResourceProperties.Kind == "" {
+					return nil, fmt.Errorf("chaining two unknown nodes (kindless-to-kindless) is not supported - at least one node in a relationship must have a known kind")
+				}
+			}
 		}
 	}
 
@@ -1115,6 +1122,11 @@ func (e *QueryExpandedError) Error() string {
 
 func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, results *QueryResult, filteredResults map[string][]map[string]interface{}) (bool, error) {
 	logDebug(fmt.Sprintf("Processing relationship: %+v\n", rel))
+
+	// Check for kindless-to-kindless chain first
+	if rel.LeftNode.ResourceProperties.Kind == "" && rel.RightNode.ResourceProperties.Kind == "" {
+		return false, fmt.Errorf("chaining two unknown nodes (kindless-to-kindless) is not supported - at least one node in a relationship must have a known kind")
+	}
 
 	// Determine relationship type and fetch related resources
 	var relType RelationshipType
@@ -2669,4 +2681,91 @@ func isKindless(nodeName string, kindlessNodes []*NodePattern) bool {
 		}
 	}
 	return false
+}
+
+func (q *QueryExecutor) validateRelationship(rel *Relationship, c *MatchClause) (bool, error) {
+	logDebug(fmt.Sprintf("validateRelationship: Starting validation for left node kind=%s, right node kind=%s",
+		rel.LeftNode.ResourceProperties.Kind,
+		rel.RightNode.ResourceProperties.Kind))
+
+	// Check if we have a kindless-to-kindless chain
+	if rel.LeftNode.ResourceProperties.Kind == "" && rel.RightNode.ResourceProperties.Kind == "" {
+		logDebug("validateRelationship: Detected kindless-to-kindless chain")
+		return false, fmt.Errorf("chaining two unknown nodes (kindless-to-kindless) is not supported - at least one node in a relationship must have a known kind")
+	}
+
+	// Resolve kinds if needed
+	if rel.LeftNode.ResourceProperties.Kind == "" || rel.RightNode.ResourceProperties.Kind == "" {
+		logDebug("validateRelationship: Attempting to resolve unknown kinds")
+		// Try to resolve the kind using relationships
+		potentialKinds := FindPotentialKindsIntersection(c.Relationships, q.provider)
+		logDebug(fmt.Sprintf("validateRelationship: Found potential kinds: %v", potentialKinds))
+
+		if len(potentialKinds) == 0 {
+			logDebug("validateRelationship: No potential kinds found")
+			return false, fmt.Errorf("unable to determine kind for nodes in relationship")
+		}
+		if len(potentialKinds) > 1 {
+			logDebug(fmt.Sprintf("validateRelationship: Multiple potential kinds found: %v", potentialKinds))
+			// Instead of expanding the query here, we'll let rewriteQueryForKindlessNodes handle it
+			return false, &QueryExpandedError{ExpandedQuery: "needs_rewrite"}
+		}
+		if rel.LeftNode.ResourceProperties.Kind == "" {
+			logDebug(fmt.Sprintf("validateRelationship: Setting left node kind to %s", potentialKinds[0]))
+			rel.LeftNode.ResourceProperties.Kind = potentialKinds[0]
+		}
+		if rel.RightNode.ResourceProperties.Kind == "" {
+			logDebug(fmt.Sprintf("validateRelationship: Setting right node kind to %s", potentialKinds[0]))
+			rel.RightNode.ResourceProperties.Kind = potentialKinds[0]
+		}
+	}
+
+	leftKind, err := q.findGVR(rel.LeftNode.ResourceProperties.Kind)
+	if err != nil {
+		logDebug(fmt.Sprintf("validateRelationship: Error finding GVR for left kind: %v", err))
+		return false, fmt.Errorf("error finding API resource >> %s", err)
+	}
+	rightKind, err := q.findGVR(rel.RightNode.ResourceProperties.Kind)
+	if err != nil {
+		logDebug(fmt.Sprintf("validateRelationship: Error finding GVR for right kind: %v", err))
+		return false, fmt.Errorf("error finding API resource >> %s", err)
+	}
+
+	logDebug(fmt.Sprintf("validateRelationship: Resolved GVRs - left: %v, right: %v", leftKind, rightKind))
+
+	var relType RelationshipType
+
+	if rightKind.Resource == "namespaces" || leftKind.Resource == "namespaces" {
+		relType = NamespaceHasResource
+		logDebug("validateRelationship: Set relationship type to NamespaceHasResource")
+	}
+
+	if relType == "" {
+		logDebug("validateRelationship: Searching for relationship type in rules")
+		for _, resourceRelationship := range relationshipRules {
+			logDebug(fmt.Sprintf("validateRelationship: Checking rule - KindA: %s, KindB: %s",
+				resourceRelationship.KindA, resourceRelationship.KindB))
+			if (strings.EqualFold(leftKind.Resource, resourceRelationship.KindA) && strings.EqualFold(rightKind.Resource, resourceRelationship.KindB)) ||
+				(strings.EqualFold(rightKind.Resource, resourceRelationship.KindA) && strings.EqualFold(leftKind.Resource, resourceRelationship.KindB)) {
+				relType = resourceRelationship.Relationship
+				logDebug(fmt.Sprintf("validateRelationship: Found matching relationship type: %s", relType))
+				break
+			}
+		}
+	}
+
+	if relType == "" {
+		logDebug(fmt.Sprintf("validateRelationship: No relationship type found between %s and %s", leftKind, rightKind))
+		// no relationship type found, error out
+		return false, fmt.Errorf("relationship type not found between %s and %s", leftKind, rightKind)
+	}
+
+	_, err = findRuleByRelationshipType(relType)
+	if err != nil {
+		logDebug(fmt.Sprintf("validateRelationship: Error finding rule for relationship type: %v", err))
+		return false, fmt.Errorf("error determining relationship type >> %s", err)
+	}
+
+	logDebug("validateRelationship: Successfully validated relationship")
+	return true, nil
 }

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -462,9 +462,9 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				}
 
 				// loop over the resources array in the resultMap for the foreign node and create the resource
-				for _, foreignResource := range resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{}) {
+				for idx, foreignResource := range resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{}) {
 					var name string
-					foreignSpec := resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{})[0]
+					foreignSpec := resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{})[idx]
 
 					fields := append([]string{criteriaField}, defaultPropFields...)
 					foreignFields := append([]string{foreignCriteriaField}, foreignDefaultPropFields...)

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -56,6 +56,8 @@ var (
 	AllNamespaces bool
 	CleanOutput   bool
 	NoColor       bool
+	// For testing
+	mockFindPotentialKinds func([]*Relationship) []string
 )
 
 // Add the apiRequest type definition
@@ -743,7 +745,15 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 	}
 
 	// Find potential kinds for each kindless node
-	potentialKinds := FindPotentialKindsIntersection(relationships)
+	var potentialKinds []string
+	if mockFindPotentialKinds != nil {
+		// Use mock function in tests
+		potentialKinds = mockFindPotentialKinds(relationships)
+	} else {
+		// Use real function in production
+		potentialKinds = FindPotentialKindsIntersection(relationships)
+	}
+
 	if len(potentialKinds) == 0 {
 		return nil, fmt.Errorf("unable to determine kind for nodes in relationship")
 	}

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -1123,11 +1123,6 @@ func (e *QueryExpandedError) Error() string {
 func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, results *QueryResult, filteredResults map[string][]map[string]interface{}) (bool, error) {
 	logDebug(fmt.Sprintf("Processing relationship: %+v\n", rel))
 
-	// Check for kindless-to-kindless chain first
-	if rel.LeftNode.ResourceProperties.Kind == "" && rel.RightNode.ResourceProperties.Kind == "" {
-		return false, fmt.Errorf("chaining two unknown nodes (kindless-to-kindless) is not supported - at least one node in a relationship must have a known kind")
-	}
-
 	// Determine relationship type and fetch related resources
 	var relType RelationshipType
 
@@ -2687,12 +2682,6 @@ func (q *QueryExecutor) validateRelationship(rel *Relationship, c *MatchClause) 
 	logDebug(fmt.Sprintf("validateRelationship: Starting validation for left node kind=%s, right node kind=%s",
 		rel.LeftNode.ResourceProperties.Kind,
 		rel.RightNode.ResourceProperties.Kind))
-
-	// Check if we have a kindless-to-kindless chain
-	if rel.LeftNode.ResourceProperties.Kind == "" && rel.RightNode.ResourceProperties.Kind == "" {
-		logDebug("validateRelationship: Detected kindless-to-kindless chain")
-		return false, fmt.Errorf("chaining two unknown nodes (kindless-to-kindless) is not supported - at least one node in a relationship must have a known kind")
-	}
 
 	// Resolve kinds if needed
 	if rel.LeftNode.ResourceProperties.Kind == "" || rel.RightNode.ResourceProperties.Kind == "" {

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -313,6 +313,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				if resultMap[nodeId] == nil {
 					// Skip error for expanded node identifiers
 					if strings.Contains(nodeId, "__exp__") {
+						debugLog("skipping error trying to delete expanded node identifier %s", nodeId)
 						continue
 					}
 					return *results, fmt.Errorf("node identifier %s not found in result map", nodeId)

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -427,11 +427,26 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 		case *ReturnClause:
 			nodeIds := []string{}
+			expandedNodeIds := make(map[string][]string) // Map original nodeId to its expanded versions
+
+			// First pass: collect all nodeIds and their expanded versions
 			for _, item := range c.Items {
 				// generate a unique list of nodeIds
 				nodeId := strings.Split(item.JsonPath, ".")[0]
 				if !slices.Contains(nodeIds, nodeId) {
 					nodeIds = append(nodeIds, nodeId)
+
+					// Check if this is an expanded node by looking for all keys in resultMap
+					// that start with this nodeId followed by underscore
+					var expandedIds []string
+					for key := range resultMap {
+						if strings.HasPrefix(key, nodeId+"_") {
+							expandedIds = append(expandedIds, key)
+						}
+					}
+					if len(expandedIds) > 0 {
+						expandedNodeIds[nodeId] = expandedIds
+					}
 				}
 			}
 
@@ -443,175 +458,354 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 			for _, item := range c.Items {
 				nodeId := strings.Split(item.JsonPath, ".")[0]
-				if resultMap[nodeId] == nil {
-					return *results, fmt.Errorf("node identifier %s not found in return clause", nodeId)
-				}
 
-				pathParts := strings.Split(item.JsonPath, ".")[1:]
-				pathStr := "$." + strings.Join(pathParts, ".")
-
-				if pathStr == "$." {
-					pathStr = "$"
-				}
-
-				if results.Data[nodeId] == nil {
-					results.Data[nodeId] = []interface{}{}
-				}
-				var aggregateResult interface{}
-
-				for idx, resource := range resultMap[nodeId].([]map[string]interface{}) {
-					// Ensure that the results.Data[nodeId] slice has enough elements to store the current resource.
-					// If the current index (idx) is beyond the current length of the slice,
-					// append a new empty map to the slice to accommodate the new data.
-					if len(results.Data[nodeId].([]interface{})) <= idx {
-						results.Data[nodeId] = append(results.Data[nodeId].([]interface{}), make(map[string]interface{}))
-					}
-					currentMap := results.Data[nodeId].([]interface{})[idx].(map[string]interface{})
-
-					result, err := jsonpath.JsonPathLookup(resource, pathStr)
-					if err != nil {
-						logDebug("Path not found:", item.JsonPath)
-						result = nil
-					}
-
-					switch strings.ToUpper(item.Aggregate) {
-					case "COUNT":
-						if aggregateResult == nil {
-							aggregateResult = 0
+				// Check if this nodeId has expanded versions
+				if expandedIds, hasExpanded := expandedNodeIds[nodeId]; hasExpanded {
+					// Process each expanded version
+					for _, expandedId := range expandedIds {
+						if resultMap[expandedId] == nil {
+							continue
 						}
-						aggregateResult = aggregateResult.(int) + 1
-					case "SUM":
-						if result != nil {
+
+						// Create the expanded path by replacing the original nodeId with the expanded one
+						expandedPath := strings.Replace(item.JsonPath, nodeId, expandedId, 1)
+						pathParts := strings.Split(expandedPath, ".")[1:]
+						pathStr := "$." + strings.Join(pathParts, ".")
+
+						if pathStr == "$." {
+							pathStr = "$"
+						}
+
+						if results.Data[expandedId] == nil {
+							results.Data[expandedId] = []interface{}{}
+						}
+						var aggregateResult interface{}
+
+						for idx, resource := range resultMap[expandedId].([]map[string]interface{}) {
+							// Ensure that the results.Data[expandedId] slice has enough elements
+							if len(results.Data[expandedId].([]interface{})) <= idx {
+								results.Data[expandedId] = append(results.Data[expandedId].([]interface{}), make(map[string]interface{}))
+							}
+							currentMap := results.Data[expandedId].([]interface{})[idx].(map[string]interface{})
+
+							result, err := jsonpath.JsonPathLookup(resource, pathStr)
+							if err != nil {
+								logDebug("Path not found:", expandedPath)
+								result = nil
+							}
+
+							switch strings.ToUpper(item.Aggregate) {
+							case "COUNT":
+								if aggregateResult == nil {
+									aggregateResult = 0
+								}
+								aggregateResult = aggregateResult.(int) + 1
+							case "SUM":
+								if result != nil {
+									if aggregateResult == nil {
+										aggregateResult = reflect.ValueOf(result).Interface()
+									} else {
+										v1 := reflect.ValueOf(aggregateResult)
+										v2 := reflect.ValueOf(result)
+										v1 = reflect.ValueOf(v1.Interface()).Convert(v1.Type())
+										if v1.Kind() == reflect.Ptr {
+											v1 = v1.Elem()
+										}
+										if v2.Kind() == reflect.Ptr {
+											v2 = v2.Elem()
+										}
+
+										isCPUResource := strings.Contains(pathStr, "resources.limits.cpu") || strings.Contains(pathStr, "resources.requests.cpu")
+										isMemoryResource := strings.Contains(pathStr, "resources.limits.memory") || strings.Contains(pathStr, "resources.requests.memory")
+
+										switch v1.Kind() {
+										case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+											aggregateResult = v1.Int() + v2.Int()
+										case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+											aggregateResult = v1.Uint() + v2.Uint()
+										case reflect.Float32, reflect.Float64:
+											aggregateResult = v1.Float() + v2.Float()
+										case reflect.String:
+											if isCPUResource {
+												v1Cpu, err := convertToMilliCPU(v1.String())
+												if err != nil {
+													return *results, fmt.Errorf("error processing cpu resources value: %v", err)
+												}
+												v2Cpu, err := convertToMilliCPU(v2.String())
+												if err != nil {
+													return *results, fmt.Errorf("error processing cpu resources value: %v", err)
+												}
+
+												aggregateResult = convertMilliCPUToStandard(v1Cpu + v2Cpu)
+											} else if isMemoryResource {
+												v1Mem, err := convertMemoryToBytes(v1.String())
+												if err != nil {
+													return *results, fmt.Errorf("error processing memory resources value: %v", err)
+												}
+												v2Mem, err := convertMemoryToBytes(v2.String())
+												if err != nil {
+													return *results, fmt.Errorf("error processing memory resources value: %v", err)
+												}
+
+												aggregateResult = convertBytesToMemory(v1Mem + v2Mem)
+											}
+										case reflect.Slice:
+											v1Strs, err := convertToStringSlice(v1)
+											if err != nil {
+												return *results, fmt.Errorf("error converting v1 to string slice: %v", err)
+											}
+
+											v2Strs, err := convertToStringSlice(v2)
+											if err != nil {
+												return *results, fmt.Errorf("error converting v2 to string slice: %v", err)
+											}
+
+											if isCPUResource {
+												v1CpuSum, err := sumMilliCPU(v1Strs)
+												if err != nil {
+													return *results, fmt.Errorf("error processing v1 cpu value: %v", err)
+												}
+
+												v2CpuSum, err := sumMilliCPU(v2Strs)
+												if err != nil {
+													return *results, fmt.Errorf("error processing v2 cpu value: %v", err)
+												}
+
+												aggregateResult = []string{convertMilliCPUToStandard(v1CpuSum + v2CpuSum)}
+											} else if isMemoryResource {
+												v1MemSum, err := sumMemoryBytes(v1Strs)
+												if err != nil {
+													return *results, fmt.Errorf("error processing v1 memory value: %v", err)
+												}
+
+												v2MemSum, err := sumMemoryBytes(v2Strs)
+												if err != nil {
+													return *results, fmt.Errorf("error processing v2 memory value: %v", err)
+												}
+
+												aggregateResult = []string{convertBytesToMemory(v1MemSum + v2MemSum)}
+											}
+										default:
+											// Handle unsupported types or error out
+											return *results, fmt.Errorf("unsupported type for SUM: %v", v1.Kind())
+										}
+									}
+								}
+							}
+
+							if item.Aggregate == "" {
+								key := item.Alias
+								if key == "" {
+									if len(pathParts) == 1 {
+										key = pathParts[0]
+									} else if len(pathParts) > 1 {
+										nestedMap := currentMap
+										for i := 0; i < len(pathParts)-1; i++ {
+											if _, exists := nestedMap[pathParts[i]]; !exists {
+												nestedMap[pathParts[i]] = make(map[string]interface{})
+											}
+											nestedMap = nestedMap[pathParts[i]].(map[string]interface{})
+										}
+										nestedMap[pathParts[len(pathParts)-1]] = result
+										continue
+									} else {
+										key = "$"
+									}
+								}
+								currentMap[key] = result
+							}
+						}
+
+						if item.Aggregate != "" {
+							if results.Data["aggregate"] == nil {
+								results.Data["aggregate"] = make(map[string]interface{})
+							}
+							aggregateMap := results.Data["aggregate"].(map[string]interface{})
+
+							key := item.Alias
+							if key == "" {
+								key = strings.ToLower(item.Aggregate) + ":" + expandedId + "." + strings.Replace(pathStr, "$.", "", 1)
+							}
+
+							if slice, ok := aggregateResult.([]interface{}); ok && len(slice) == 0 {
+								aggregateResult = nil
+							} else if strSlice, ok := aggregateResult.([]string); ok && len(strSlice) == 1 {
+								aggregateResult = strSlice[0]
+							}
+							aggregateMap[key] = aggregateResult
+						}
+					}
+				} else {
+					// Original logic for non-expanded nodes
+					if resultMap[nodeId] == nil {
+						return *results, fmt.Errorf("node identifier %s not found in return clause", nodeId)
+					}
+
+					pathParts := strings.Split(item.JsonPath, ".")[1:]
+					pathStr := "$." + strings.Join(pathParts, ".")
+
+					if pathStr == "$." {
+						pathStr = "$"
+					}
+
+					if results.Data[nodeId] == nil {
+						results.Data[nodeId] = []interface{}{}
+					}
+					var aggregateResult interface{}
+
+					for idx, resource := range resultMap[nodeId].([]map[string]interface{}) {
+						// Ensure that the results.Data[nodeId] slice has enough elements
+						if len(results.Data[nodeId].([]interface{})) <= idx {
+							results.Data[nodeId] = append(results.Data[nodeId].([]interface{}), make(map[string]interface{}))
+						}
+						currentMap := results.Data[nodeId].([]interface{})[idx].(map[string]interface{})
+
+						result, err := jsonpath.JsonPathLookup(resource, pathStr)
+						if err != nil {
+							logDebug("Path not found:", pathStr)
+							result = nil
+						}
+
+						switch strings.ToUpper(item.Aggregate) {
+						case "COUNT":
 							if aggregateResult == nil {
-								aggregateResult = reflect.ValueOf(result).Interface()
-							} else {
-								v1 := reflect.ValueOf(aggregateResult)
-								v2 := reflect.ValueOf(result)
-								v1 = reflect.ValueOf(v1.Interface()).Convert(v1.Type())
-								if v1.Kind() == reflect.Ptr {
-									v1 = v1.Elem()
-								}
-								if v2.Kind() == reflect.Ptr {
-									v2 = v2.Elem()
-								}
-
-								isCPUResource := strings.Contains(pathStr, "resources.limits.cpu") || strings.Contains(pathStr, "resources.requests.cpu")
-								isMemoryResource := strings.Contains(pathStr, "resources.limits.memory") || strings.Contains(pathStr, "resources.requests.memory")
-
-								switch v1.Kind() {
-								case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-									aggregateResult = v1.Int() + v2.Int()
-								case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-									aggregateResult = v1.Uint() + v2.Uint()
-								case reflect.Float32, reflect.Float64:
-									aggregateResult = v1.Float() + v2.Float()
-								case reflect.String:
-									if isCPUResource {
-										v1Cpu, err := convertToMilliCPU(v1.String())
-										if err != nil {
-											return *results, fmt.Errorf("error processing cpu resources value: %v", err)
-										}
-										v2Cpu, err := convertToMilliCPU(v2.String())
-										if err != nil {
-											return *results, fmt.Errorf("error processing cpu resources value: %v", err)
-										}
-
-										aggregateResult = convertMilliCPUToStandard(v1Cpu + v2Cpu)
-									} else if isMemoryResource {
-										v1Mem, err := convertMemoryToBytes(v1.String())
-										if err != nil {
-											return *results, fmt.Errorf("error processing memory resources value: %v", err)
-										}
-										v2Mem, err := convertMemoryToBytes(v2.String())
-										if err != nil {
-											return *results, fmt.Errorf("error processing memory resources value: %v", err)
-										}
-
-										aggregateResult = convertBytesToMemory(v1Mem + v2Mem)
+								aggregateResult = 0
+							}
+							aggregateResult = aggregateResult.(int) + 1
+						case "SUM":
+							if result != nil {
+								if aggregateResult == nil {
+									aggregateResult = reflect.ValueOf(result).Interface()
+								} else {
+									v1 := reflect.ValueOf(aggregateResult)
+									v2 := reflect.ValueOf(result)
+									v1 = reflect.ValueOf(v1.Interface()).Convert(v1.Type())
+									if v1.Kind() == reflect.Ptr {
+										v1 = v1.Elem()
 									}
-								case reflect.Slice:
-									v1Strs, err := convertToStringSlice(v1)
-									if err != nil {
-										return *results, fmt.Errorf("error converting v1 to string slice: %v", err)
+									if v2.Kind() == reflect.Ptr {
+										v2 = v2.Elem()
 									}
 
-									v2Strs, err := convertToStringSlice(v2)
-									if err != nil {
-										return *results, fmt.Errorf("error converting v2 to string slice: %v", err)
+									isCPUResource := strings.Contains(pathStr, "resources.limits.cpu") || strings.Contains(pathStr, "resources.requests.cpu")
+									isMemoryResource := strings.Contains(pathStr, "resources.limits.memory") || strings.Contains(pathStr, "resources.requests.memory")
+
+									switch v1.Kind() {
+									case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+										aggregateResult = v1.Int() + v2.Int()
+									case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+										aggregateResult = v1.Uint() + v2.Uint()
+									case reflect.Float32, reflect.Float64:
+										aggregateResult = v1.Float() + v2.Float()
+									case reflect.String:
+										if isCPUResource {
+											v1Cpu, err := convertToMilliCPU(v1.String())
+											if err != nil {
+												return *results, fmt.Errorf("error processing cpu resources value: %v", err)
+											}
+											v2Cpu, err := convertToMilliCPU(v2.String())
+											if err != nil {
+												return *results, fmt.Errorf("error processing cpu resources value: %v", err)
+											}
+
+											aggregateResult = convertMilliCPUToStandard(v1Cpu + v2Cpu)
+										} else if isMemoryResource {
+											v1Mem, err := convertMemoryToBytes(v1.String())
+											if err != nil {
+												return *results, fmt.Errorf("error processing memory resources value: %v", err)
+											}
+											v2Mem, err := convertMemoryToBytes(v2.String())
+											if err != nil {
+												return *results, fmt.Errorf("error processing memory resources value: %v", err)
+											}
+
+											aggregateResult = convertBytesToMemory(v1Mem + v2Mem)
+										}
+									case reflect.Slice:
+										v1Strs, err := convertToStringSlice(v1)
+										if err != nil {
+											return *results, fmt.Errorf("error converting v1 to string slice: %v", err)
+										}
+
+										v2Strs, err := convertToStringSlice(v2)
+										if err != nil {
+											return *results, fmt.Errorf("error converting v2 to string slice: %v", err)
+										}
+
+										if isCPUResource {
+											v1CpuSum, err := sumMilliCPU(v1Strs)
+											if err != nil {
+												return *results, fmt.Errorf("error processing v1 cpu value: %v", err)
+											}
+
+											v2CpuSum, err := sumMilliCPU(v2Strs)
+											if err != nil {
+												return *results, fmt.Errorf("error processing v2 cpu value: %v", err)
+											}
+
+											aggregateResult = []string{convertMilliCPUToStandard(v1CpuSum + v2CpuSum)}
+										} else if isMemoryResource {
+											v1MemSum, err := sumMemoryBytes(v1Strs)
+											if err != nil {
+												return *results, fmt.Errorf("error processing v1 memory value: %v", err)
+											}
+
+											v2MemSum, err := sumMemoryBytes(v2Strs)
+											if err != nil {
+												return *results, fmt.Errorf("error processing v2 memory value: %v", err)
+											}
+
+											aggregateResult = []string{convertBytesToMemory(v1MemSum + v2MemSum)}
+										}
+									default:
+										// Handle unsupported types or error out
+										return *results, fmt.Errorf("unsupported type for SUM: %v", v1.Kind())
 									}
-
-									if isCPUResource {
-										v1CpuSum, err := sumMilliCPU(v1Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v1 cpu value: %v", err)
-										}
-
-										v2CpuSum, err := sumMilliCPU(v2Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v2 cpu value: %v", err)
-										}
-
-										aggregateResult = []string{convertMilliCPUToStandard(v1CpuSum + v2CpuSum)}
-									} else if isMemoryResource {
-										v1MemSum, err := sumMemoryBytes(v1Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v1 memory value: %v", err)
-										}
-
-										v2MemSum, err := sumMemoryBytes(v2Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v2 memory value: %v", err)
-										}
-
-										aggregateResult = []string{convertBytesToMemory(v1MemSum + v2MemSum)}
-									}
-								default:
-									// Handle unsupported types or error out
-									return *results, fmt.Errorf("unsupported type for SUM: %v", v1.Kind())
 								}
 							}
 						}
+
+						if item.Aggregate == "" {
+							key := item.Alias
+							if key == "" {
+								if len(pathParts) == 1 {
+									key = pathParts[0]
+								} else if len(pathParts) > 1 {
+									nestedMap := currentMap
+									for i := 0; i < len(pathParts)-1; i++ {
+										if _, exists := nestedMap[pathParts[i]]; !exists {
+											nestedMap[pathParts[i]] = make(map[string]interface{})
+										}
+										nestedMap = nestedMap[pathParts[i]].(map[string]interface{})
+									}
+									nestedMap[pathParts[len(pathParts)-1]] = result
+									continue
+								} else {
+									key = "$"
+								}
+							}
+							currentMap[key] = result
+						}
 					}
 
-					if item.Aggregate == "" {
+					if item.Aggregate != "" {
+						if results.Data["aggregate"] == nil {
+							results.Data["aggregate"] = make(map[string]interface{})
+						}
+						aggregateMap := results.Data["aggregate"].(map[string]interface{})
+
 						key := item.Alias
 						if key == "" {
-							if len(pathParts) == 1 {
-								key = pathParts[0]
-							} else if len(pathParts) > 1 {
-								nestedMap := currentMap
-								for i := 0; i < len(pathParts)-1; i++ {
-									if _, exists := nestedMap[pathParts[i]]; !exists {
-										nestedMap[pathParts[i]] = make(map[string]interface{})
-									}
-									nestedMap = nestedMap[pathParts[i]].(map[string]interface{})
-								}
-								nestedMap[pathParts[len(pathParts)-1]] = result
-								continue
-							} else {
-								key = "$"
-							}
+							key = strings.ToLower(item.Aggregate) + ":" + nodeId + "." + strings.Replace(pathStr, "$.", "", 1)
 						}
-						currentMap[key] = result
-					}
-				}
-				if item.Aggregate != "" {
-					if results.Data["aggregate"] == nil {
-						results.Data["aggregate"] = make(map[string]interface{})
-					}
-					aggregateMap := results.Data["aggregate"].(map[string]interface{})
 
-					key := item.Alias
-					if key == "" {
-						key = strings.ToLower(item.Aggregate) + ":" + nodeId + "." + strings.Replace(pathStr, "$.", "", 1)
+						if slice, ok := aggregateResult.([]interface{}); ok && len(slice) == 0 {
+							aggregateResult = nil
+						} else if strSlice, ok := aggregateResult.([]string); ok && len(strSlice) == 1 {
+							aggregateResult = strSlice[0]
+						}
+						aggregateMap[key] = aggregateResult
 					}
-
-					if slice, ok := aggregateResult.([]interface{}); ok && len(slice) == 0 {
-						aggregateResult = nil
-					} else if strSlice, ok := aggregateResult.([]string); ok && len(strSlice) == 1 {
-						aggregateResult = strSlice[0]
-					}
-					aggregateMap[key] = aggregateResult
 				}
 			}
 
@@ -631,9 +825,6 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, results *QueryResult, filteredResults map[string][]map[string]interface{}) (bool, error) {
 	logDebug(fmt.Sprintf("Processing relationship: %+v\n", rel))
 
-	// Determine relationship type and fetch related resources
-	var relType RelationshipType
-
 	// Resolve kinds if needed
 	if rel.LeftNode.ResourceProperties.Kind == "" || rel.RightNode.ResourceProperties.Kind == "" {
 		// Try to resolve the kind using relationships
@@ -641,16 +832,84 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 		if len(potentialKinds) == 0 {
 			return false, fmt.Errorf("unable to determine kind for nodes in relationship")
 		}
-		if len(potentialKinds) > 1 {
-			return false, fmt.Errorf("ambiguous kinds for nodes in relationship - possible kinds: %v", potentialKinds)
-		}
+
+		// Create a map to store results for each kind
+		allResults := make(map[string][]map[string]interface{})
+		var processedAny bool
+
+		// Store the original node names for filtering
+		var originalLeftName, originalRightName string
 		if rel.LeftNode.ResourceProperties.Kind == "" {
-			rel.LeftNode.ResourceProperties.Kind = potentialKinds[0]
+			originalLeftName = rel.LeftNode.ResourceProperties.Name
 		}
 		if rel.RightNode.ResourceProperties.Kind == "" {
-			rel.RightNode.ResourceProperties.Kind = potentialKinds[0]
+			originalRightName = rel.RightNode.ResourceProperties.Name
 		}
+
+		// Process each potential kind
+		for _, kind := range potentialKinds {
+			// Create a copy of the relationship with this specific kind
+			relCopy := *rel
+			if rel.LeftNode.ResourceProperties.Kind == "" {
+				relCopy.LeftNode = &NodePattern{
+					ResourceProperties: &ResourceProperties{
+						Name: fmt.Sprintf("%s_%s", rel.LeftNode.ResourceProperties.Name, strings.ToLower(kind)),
+						Kind: kind,
+					},
+					IsAnonymous: rel.LeftNode.IsAnonymous,
+				}
+			}
+			if rel.RightNode.ResourceProperties.Kind == "" {
+				relCopy.RightNode = &NodePattern{
+					ResourceProperties: &ResourceProperties{
+						Name: fmt.Sprintf("%s_%s", rel.RightNode.ResourceProperties.Name, strings.ToLower(kind)),
+						Kind: kind,
+					},
+					IsAnonymous: rel.RightNode.IsAnonymous,
+				}
+			}
+
+			// Process this specific relationship
+			success, err := q.processSingleKindRelationship(&relCopy, c, results, filteredResults)
+			if err == nil && success {
+				processedAny = true
+				// Store the results for this kind
+				if relCopy.LeftNode.ResourceProperties.Kind == kind {
+					allResults[relCopy.LeftNode.ResourceProperties.Name] = filteredResults[relCopy.LeftNode.ResourceProperties.Name]
+				}
+				if relCopy.RightNode.ResourceProperties.Kind == kind {
+					allResults[relCopy.RightNode.ResourceProperties.Name] = filteredResults[relCopy.RightNode.ResourceProperties.Name]
+				}
+
+				// Also store the results for the non-expanded nodes
+				if originalLeftName != "" && filteredResults[relCopy.LeftNode.ResourceProperties.Name] != nil {
+					if resultMap[originalLeftName] == nil {
+						resultMap[originalLeftName] = filteredResults[relCopy.LeftNode.ResourceProperties.Name]
+					}
+				}
+				if originalRightName != "" && filteredResults[relCopy.RightNode.ResourceProperties.Name] != nil {
+					if resultMap[originalRightName] == nil {
+						resultMap[originalRightName] = filteredResults[relCopy.RightNode.ResourceProperties.Name]
+					}
+				}
+			}
+		}
+
+		// Update the results map with all collected results
+		for name, resources := range allResults {
+			filteredResults[name] = resources
+			resultMap[name] = resources
+		}
+
+		return processedAny, nil
 	}
+
+	return q.processSingleKindRelationship(rel, c, results, filteredResults)
+}
+
+// processSingleKindRelationship handles a relationship where both kinds are known
+func (q *QueryExecutor) processSingleKindRelationship(rel *Relationship, c *MatchClause, results *QueryResult, filteredResults map[string][]map[string]interface{}) (bool, error) {
+	var relType RelationshipType
 
 	leftKind, err := q.findGVR(rel.LeftNode.ResourceProperties.Kind)
 	if err != nil {
@@ -676,7 +935,7 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 
 	if relType == "" {
 		// no relationship type found, error out
-		return false, fmt.Errorf("relationship type not found between %s and %s", leftKind, rightKind)
+		return false, fmt.Errorf("relationship type not found between %s and %s", leftKind.Resource, rightKind.Resource)
 	}
 
 	rule, err := findRuleByRelationshipType(relType)
@@ -764,41 +1023,80 @@ func (q *QueryExecutor) processNodes(c *MatchClause, results *QueryResult) error
 			if len(potentialKinds) == 0 {
 				return fmt.Errorf("unable to determine kind for node '%s' - no relationships found", node.ResourceProperties.Name)
 			}
-			if len(potentialKinds) > 1 {
-				return fmt.Errorf("ambiguous kind for node '%s' - possible kinds: %v", node.ResourceProperties.Name, potentialKinds)
-			}
-			node.ResourceProperties.Kind = potentialKinds[0]
-		}
 
-		// check if the node has already been fetched
-		cacheKey, err := q.resourcePropertyName(node)
-		if err != nil {
-			return fmt.Errorf("error getting resource property name: %v", err)
-		}
-		if resultCache[cacheKey] == nil {
-			err := getNodeResources(node, q, c.ExtraFilters)
+			// Process each potential kind
+			for _, kind := range potentialKinds {
+				// Create a new node with this specific kind
+				nodeCopy := &NodePattern{
+					ResourceProperties: &ResourceProperties{
+						Name: fmt.Sprintf("%s_%s", node.ResourceProperties.Name, strings.ToLower(kind)),
+						Kind: kind,
+					},
+					IsAnonymous: node.IsAnonymous,
+				}
+
+				// Check if the node has already been fetched
+				cacheKey, err := q.resourcePropertyName(nodeCopy)
+				if err != nil {
+					return fmt.Errorf("error getting resource property name: %v", err)
+				}
+				if resultCache[cacheKey] == nil {
+					err := getNodeResources(nodeCopy, q, c.ExtraFilters)
+					if err != nil {
+						continue // Skip this kind if there's an error
+					}
+					resources := resultMap[nodeCopy.ResourceProperties.Name].([]map[string]interface{})
+					for _, resource := range resources {
+						metadata, ok := resource["metadata"].(map[string]interface{})
+						if !ok {
+							continue
+						}
+						graphNode := Node{
+							Id:   nodeCopy.ResourceProperties.Name,
+							Kind: resource["kind"].(string),
+							Name: metadata["name"].(string),
+						}
+						if graphNode.Kind != "Namespace" {
+							graphNode.Namespace = getNamespaceName(metadata)
+						}
+						results.Graph.Nodes = append(results.Graph.Nodes, graphNode)
+					}
+				} else if resultMap[nodeCopy.ResourceProperties.Name] == nil {
+					// Copy from cache using the original name
+					resultMap[nodeCopy.ResourceProperties.Name] = resultCache[cacheKey]
+				}
+			}
+		} else {
+			// Handle nodes with known kinds
+			cacheKey, err := q.resourcePropertyName(node)
 			if err != nil {
-				return fmt.Errorf("error getting node resources >> %s", err)
+				return fmt.Errorf("error getting resource property name: %v", err)
 			}
-			resources := resultMap[node.ResourceProperties.Name].([]map[string]interface{})
-			for _, resource := range resources {
-				metadata, ok := resource["metadata"].(map[string]interface{})
-				if !ok {
-					continue
+			if resultCache[cacheKey] == nil {
+				err := getNodeResources(node, q, c.ExtraFilters)
+				if err != nil {
+					return fmt.Errorf("error getting node resources >> %s", err)
 				}
-				node := Node{
-					Id:   node.ResourceProperties.Name,
-					Kind: resource["kind"].(string),
-					Name: metadata["name"].(string),
+				resources := resultMap[node.ResourceProperties.Name].([]map[string]interface{})
+				for _, resource := range resources {
+					metadata, ok := resource["metadata"].(map[string]interface{})
+					if !ok {
+						continue
+					}
+					graphNode := Node{
+						Id:   node.ResourceProperties.Name,
+						Kind: resource["kind"].(string),
+						Name: metadata["name"].(string),
+					}
+					if graphNode.Kind != "Namespace" {
+						graphNode.Namespace = getNamespaceName(metadata)
+					}
+					results.Graph.Nodes = append(results.Graph.Nodes, graphNode)
 				}
-				if node.Kind != "Namespace" {
-					node.Namespace = getNamespaceName(metadata)
-				}
-				results.Graph.Nodes = append(results.Graph.Nodes, node)
+			} else if resultMap[node.ResourceProperties.Name] == nil {
+				// Copy from cache using the original name
+				resultMap[node.ResourceProperties.Name] = resultCache[cacheKey]
 			}
-		} else if resultMap[node.ResourceProperties.Name] == nil {
-			// Copy from cache using the original name
-			resultMap[node.ResourceProperties.Name] = resultCache[cacheKey]
 		}
 	}
 	return nil

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -817,7 +817,7 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 		potentialKinds = mockFindPotentialKinds(relationships)
 	} else {
 		// Use real function in production
-		potentialKinds = FindPotentialKindsIntersection(relationships)
+		potentialKinds = FindPotentialKindsIntersection(relationships, q.provider)
 	}
 
 	if len(potentialKinds) == 0 {
@@ -1122,7 +1122,7 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 	// Resolve kinds if needed
 	if rel.LeftNode.ResourceProperties.Kind == "" || rel.RightNode.ResourceProperties.Kind == "" {
 		// Try to resolve the kind using relationships
-		potentialKinds := FindPotentialKindsIntersection(c.Relationships)
+		potentialKinds := FindPotentialKindsIntersection(c.Relationships, q.provider)
 		if len(potentialKinds) == 0 {
 			return false, fmt.Errorf("unable to determine kind for nodes in relationship")
 		}
@@ -1310,7 +1310,7 @@ func (q *QueryExecutor) processNodes(c *MatchClause, results *QueryResult) error
 	for _, node := range c.Nodes {
 		if node.ResourceProperties.Kind == "" {
 			// Try to resolve the kind using relationships
-			potentialKinds := FindPotentialKindsIntersection(c.Relationships)
+			potentialKinds := FindPotentialKindsIntersection(c.Relationships, q.provider)
 			if len(potentialKinds) == 0 {
 				return fmt.Errorf("unable to determine kind for node '%s' - no relationships found", node.ResourceProperties.Name)
 			}

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -878,15 +878,25 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(ast *Expression) (*Expressi
 						seenNodes[item.JsonPath] = true
 						// Add a return item for each iteration
 						for j := 0; j < len(potentialKinds); j++ {
+							var returnItem string
 							if strings.Contains(item.JsonPath, ".") {
 								parts := strings.SplitN(item.JsonPath, ".", 2)
 								varName := fmt.Sprintf("%s__exp__%d", parts[0], j)
 								returnPath := fmt.Sprintf("%s.%s", varName, parts[1])
-								returnParts = append(returnParts, returnPath)
+								if item.Aggregate != "" {
+									returnItem = fmt.Sprintf("%s {%s}", item.Aggregate, returnPath)
+								} else {
+									returnItem = returnPath
+								}
 							} else {
 								varName := fmt.Sprintf("%s__exp__%d", item.JsonPath, j)
-								returnParts = append(returnParts, varName)
+								if item.Aggregate != "" {
+									returnItem = fmt.Sprintf("%s {%s}", item.Aggregate, varName)
+								} else {
+									returnItem = varName
+								}
 							}
+							returnParts = append(returnParts, returnItem)
 						}
 					}
 				}

--- a/pkg/core/k8s_query_test.go
+++ b/pkg/core/k8s_query_test.go
@@ -652,6 +652,20 @@ func TestRewriteQueryForKindlessNodes(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:          "Match/Where/Return with node properties and multiple potential kinds",
+			query:         `MATCH (d:Deployment)->(x {name: "test"}) WHERE x.metadata.labels.foo = "bar" RETURN d, x`,
+			mockKinds:     map[string][]string{"x": {"Pod", "ReplicaSet"}},
+			expectedQuery: `MATCH (d__exp__0:Deployment)->(x__exp__0:Pod {name: "test"}), (d__exp__1:Deployment)->(x__exp__1:ReplicaSet {name: "test"}) WHERE x__exp__0.metadata.labels.foo = "bar", x__exp__1.metadata.labels.foo = "bar" RETURN d__exp__0, x__exp__0, d__exp__1, x__exp__1`,
+			expectedError: false,
+		},
+		{
+			name:          "Match/Delete with node properties and multiple potential kinds",
+			query:         `MATCH (d:Deployment)->(x {name: "test"}) DELETE x`,
+			mockKinds:     map[string][]string{"x": {"Pod", "ReplicaSet"}},
+			expectedQuery: `MATCH (d__exp__0:Deployment)->(x__exp__0:Pod {name: "test"}), (d__exp__1:Deployment)->(x__exp__1:ReplicaSet {name: "test"}) DELETE x__exp__0, x__exp__1`,
+			expectedError: false,
+		},
+		{
 			name:          "No potential kinds found",
 			query:         "MATCH (d:Deployment)->(x) RETURN d, x",
 			mockKinds:     map[string][]string{},

--- a/pkg/core/k8s_query_test.go
+++ b/pkg/core/k8s_query_test.go
@@ -666,6 +666,20 @@ func TestRewriteQueryForKindlessNodes(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:          "Match/Return with aggregation",
+			query:         `MATCH (d:Deployment)->(x) RETURN COUNT {d}, SUM {x}`,
+			mockKinds:     map[string][]string{"x": {"Pod", "ReplicaSet"}},
+			expectedQuery: `MATCH (d__exp__0:Deployment)->(x__exp__0:Pod), (d__exp__1:Deployment)->(x__exp__1:ReplicaSet) RETURN COUNT {d__exp__0}, SUM {x__exp__0}, COUNT {d__exp__1}, SUM {x__exp__1}`,
+			expectedError: false,
+		},
+		{
+			name:          "Multiple kindless nodes with different potential kinds returning a mixture of aggregation and non-aggregation with properties",
+			query:         `MATCH (d:Deployment {name: "test"})->(x), (s:Service)->(y) RETURN d, COUNT {s}, x, SUM {y.spec.replicas}`,
+			mockKinds:     map[string][]string{"x": {"Pod", "ReplicaSet"}, "y": {"Pod", "Endpoints"}},
+			expectedQuery: `MATCH (d__exp__0:Deployment)->(x__exp__0:Pod), (s__exp__0:Service)->(y__exp__0:Pod), (d__exp__1:Deployment)->(x__exp__1:ReplicaSet), (s__exp__1:Service)->(y__exp__1:Endpoints) RETURN d__exp__0, COUNT {s__exp__0}, x__exp__0, SUM {y__exp__0.spec.replicas}, d__exp__1, COUNT {s__exp__1}, x__exp__1, SUM {y__exp__1.spec.replicas}`,
+			expectedError: false,
+		},
+		{
 			name:          "No potential kinds found",
 			query:         "MATCH (d:Deployment)->(x) RETURN d, x",
 			mockKinds:     map[string][]string{},

--- a/pkg/core/k8s_query_test.go
+++ b/pkg/core/k8s_query_test.go
@@ -723,7 +723,7 @@ func TestRewriteQueryForKindlessNodes(t *testing.T) {
 				t.Fatalf("Failed to parse query: %v", err)
 			}
 
-			// Create a query executor with mock provider
+			// Create a query executor with mock providermake
 			executor, err := NewQueryExecutor(mockProvider)
 			if err != nil {
 				t.Fatalf("Failed to create query executor: %v", err)

--- a/pkg/core/k8s_query_test.go
+++ b/pkg/core/k8s_query_test.go
@@ -691,7 +691,14 @@ func TestRewriteQueryForKindlessNodes(t *testing.T) {
 			query:         "MATCH (x) RETURN x",
 			mockKinds:     map[string][]string{},
 			expectedError: true,
-			errorContains: "unable to determine kind for nodes in relationship",
+			errorContains: "kindless nodes may only be used in a relationship",
+		},
+		{
+			name:          "Kindless-to-kindless relationship",
+			query:         "MATCH (x)->(y) RETURN x, y",
+			mockKinds:     map[string][]string{},
+			expectedError: true,
+			errorContains: "chaining two unknown nodes (kindless-to-kindless) is not supported",
 		},
 		{
 			name:          "Match/Return with AS aliases",

--- a/pkg/core/kind_resolution_test.go
+++ b/pkg/core/kind_resolution_test.go
@@ -1,0 +1,173 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFindPotentialKindsIntersection(t *testing.T) {
+	tests := []struct {
+		name          string
+		relationships []*Relationship
+		want          []string
+	}{
+		{
+			name: "single relationship with unknown left node",
+			relationships: []*Relationship{
+				{
+					LeftNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "x",
+							Kind: "",
+						},
+					},
+					RightNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "s",
+							Kind: "services",
+						},
+					},
+				},
+			},
+			want: []string{"daemonsets", "deployments", "endpoints", "ingresses", "mutatingwebhookconfigurations", "pods", "replicasets", "statefulsets", "validatingwebhookconfigurations"},
+		},
+		{
+			name: "two relationships with common kinds",
+			relationships: []*Relationship{
+				{
+					LeftNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "x",
+							Kind: "",
+						},
+					},
+					RightNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "s",
+							Kind: "services",
+						},
+					},
+				},
+				{
+					LeftNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "x",
+							Kind: "",
+						},
+					},
+					RightNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "p",
+							Kind: "pods",
+						},
+					},
+				},
+			},
+			want: []string{"daemonsets", "replicasets", "statefulsets"},
+		},
+		{
+			name:          "empty relationships",
+			relationships: []*Relationship{},
+			want:          []string{},
+		},
+		{
+			name: "no unknown kinds",
+			relationships: []*Relationship{
+				{
+					LeftNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "s",
+							Kind: "services",
+						},
+					},
+					RightNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "p",
+							Kind: "pods",
+						},
+					},
+				},
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindPotentialKindsIntersection(tt.relationships)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindPotentialKindsIntersection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAnonymousNode(t *testing.T) {
+	tests := []struct {
+		name          string
+		node          *NodePattern
+		relationships []*Relationship
+		wantErr       bool
+	}{
+		{
+			name: "non-anonymous node",
+			node: &NodePattern{
+				ResourceProperties: &ResourceProperties{
+					Name: "x",
+					Kind: "pods",
+				},
+				IsAnonymous: false,
+			},
+			relationships: []*Relationship{},
+			wantErr:       false,
+		},
+		{
+			name: "anonymous node in relationship",
+			node: &NodePattern{
+				ResourceProperties: &ResourceProperties{
+					Name: "_anon1",
+					Kind: "",
+				},
+				IsAnonymous: true,
+			},
+			relationships: []*Relationship{
+				{
+					LeftNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "_anon1",
+							Kind: "",
+						},
+					},
+					RightNode: &NodePattern{
+						ResourceProperties: &ResourceProperties{
+							Name: "s",
+							Kind: "services",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "standalone anonymous node",
+			node: &NodePattern{
+				ResourceProperties: &ResourceProperties{
+					Name: "_anon1",
+					Kind: "",
+				},
+				IsAnonymous: true,
+			},
+			relationships: []*Relationship{},
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAnonymousNode(tt.node, tt.relationships)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAnonymousNode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/core/lexer_test.go
+++ b/pkg/core/lexer_test.go
@@ -194,6 +194,42 @@ func TestLexer(t *testing.T) {
 				{Type: EOF, Literal: ""},
 			},
 		},
+		{
+			name:  "partial nodes",
+			input: "() (p) (:pod)",
+			expected: []Token{
+				{Type: LPAREN, Literal: "("},
+				{Type: RPAREN, Literal: ")"},
+				{Type: LPAREN, Literal: "("},
+				{Type: IDENT, Literal: "p"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: LPAREN, Literal: "("},
+				{Type: COLON, Literal: ":"},
+				{Type: IDENT, Literal: "pod"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		{
+			name:  "partial nodes in relationships",
+			input: "(p:pod)->()->(:service)",
+			expected: []Token{
+				{Type: LPAREN, Literal: "("},
+				{Type: IDENT, Literal: "p"},
+				{Type: COLON, Literal: ":"},
+				{Type: IDENT, Literal: "pod"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: REL_NOPROPS_RIGHT, Literal: "->"},
+				{Type: LPAREN, Literal: "("},
+				{Type: RPAREN, Literal: ")"},
+				{Type: REL_NOPROPS_RIGHT, Literal: "->"},
+				{Type: LPAREN, Literal: "("},
+				{Type: COLON, Literal: ":"},
+				{Type: IDENT, Literal: "service"},
+				{Type: RPAREN, Literal: ")"},
+				{Type: EOF, Literal: ""},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/parser.go
+++ b/pkg/core/parser.go
@@ -998,12 +998,12 @@ func FindPotentialKinds(sourceKind string) []string {
 		debugLog("FindPotentialKinds: checking rule KindA=%s, KindB=%s, Relationship=%s", rule.KindA, rule.KindB, rule.Relationship)
 
 		// If sourceKind is KindB, we want KindA (what can connect to sourceKind)
-		if strings.ToLower(rule.KindB) == sourceKind {
+		if strings.ToLower(rule.KindB) == sourceKind || strings.ToLower(rule.KindB) == sourceKind+"s" {
 			debugLog("FindPotentialKinds: matched KindB, adding KindA=%s", rule.KindA)
 			potentialKinds[rule.KindA] = true
 		}
 		// If sourceKind is KindA, we want KindB (what sourceKind can connect to)
-		if strings.ToLower(rule.KindA) == sourceKind {
+		if strings.ToLower(rule.KindA) == sourceKind || strings.ToLower(rule.KindA) == sourceKind+"s" {
 			debugLog("FindPotentialKinds: matched KindA, adding KindB=%s", rule.KindB)
 			potentialKinds[rule.KindB] = true
 		}
@@ -1026,65 +1026,70 @@ func FindPotentialKindsIntersection(relationships []*Relationship) []string {
 		return []string{}
 	}
 
-	// Initialize result with potential kinds from first relationship
-	var firstKnownKind string
-	var firstUnknownNode *NodePattern
-	if relationships[0].LeftNode.ResourceProperties.Kind == "" {
-		firstUnknownNode = relationships[0].LeftNode
-		firstKnownKind = relationships[0].RightNode.ResourceProperties.Kind
-		debugLog("FindPotentialKindsIntersection: first relationship - unknown node on left, known kind=%s", firstKnownKind)
-	} else if relationships[0].RightNode.ResourceProperties.Kind == "" {
-		firstUnknownNode = relationships[0].RightNode
-		firstKnownKind = relationships[0].LeftNode.ResourceProperties.Kind
-		debugLog("FindPotentialKindsIntersection: first relationship - unknown node on right, known kind=%s", firstKnownKind)
-	} else {
-		debugLog("FindPotentialKindsIntersection: no unknown kinds in first relationship")
-		return []string{} // No unknown kinds
+	// Check if there are any unknown kinds that need resolution
+	hasUnknownKind := false
+	for _, rel := range relationships {
+		if rel.LeftNode.ResourceProperties.Kind == "" || rel.RightNode.ResourceProperties.Kind == "" {
+			hasUnknownKind = true
+			break
+		}
 	}
 
-	debugLog("FindPotentialKindsIntersection: first relationship - unknown node=%s, known kind=%s",
-		firstUnknownNode.ResourceProperties.Name, firstKnownKind)
+	// If all kinds are known, return empty slice
+	if !hasUnknownKind {
+		debugLog("FindPotentialKindsIntersection: all kinds are known")
+		return []string{}
+	}
 
-	// Initialize result with all potential kinds from first relationship
+	// Find all known kinds in the relationships
+	knownKinds := make(map[string]bool)
+	for _, rel := range relationships {
+		if rel.LeftNode.ResourceProperties.Kind != "" {
+			knownKinds[strings.ToLower(rel.LeftNode.ResourceProperties.Kind)] = true
+		}
+		if rel.RightNode.ResourceProperties.Kind != "" {
+			knownKinds[strings.ToLower(rel.RightNode.ResourceProperties.Kind)] = true
+		}
+	}
+	debugLog("FindPotentialKindsIntersection: found known kinds=%v", knownKinds)
+
+	// If no known kinds, return empty
+	if len(knownKinds) == 0 {
+		debugLog("FindPotentialKindsIntersection: no known kinds found")
+		return []string{}
+	}
+
+	// Initialize result with potential kinds from first known kind
+	var firstKnownKind string
+	for kind := range knownKinds {
+		firstKnownKind = kind
+		break
+	}
+
 	result := make(map[string]bool)
 	for _, kind := range FindPotentialKinds(firstKnownKind) {
 		result[kind] = true
 	}
-	debugLog("FindPotentialKindsIntersection: initial potential kinds=%v", result)
+	debugLog("FindPotentialKindsIntersection: initial potential kinds from %s=%v", firstKnownKind, result)
 
-	// For each additional relationship, intersect with its potential kinds
-	for i := 1; i < len(relationships); i++ {
-		var knownKind string
-		var unknownNodePosition string
-		if relationships[i].LeftNode.ResourceProperties.Kind == "" {
-			knownKind = relationships[i].RightNode.ResourceProperties.Kind
-			unknownNodePosition = "left"
-		} else if relationships[i].RightNode.ResourceProperties.Kind == "" {
-			knownKind = relationships[i].LeftNode.ResourceProperties.Kind
-			unknownNodePosition = "right"
-		} else {
-			debugLog("FindPotentialKindsIntersection: skipping relationship %d - no unknown kinds", i)
-			continue // Skip if no unknown kinds
+	// For each additional known kind, intersect with its potential kinds
+	for kind := range knownKinds {
+		if kind == firstKnownKind {
+			continue
 		}
 
-		debugLog("FindPotentialKindsIntersection: processing relationship %d with known kind=%s, unknown node on %s", i, knownKind, unknownNodePosition)
-
-		// Get potential kinds for this relationship
-		potentialKinds := FindPotentialKinds(knownKind)
-		debugLog("FindPotentialKindsIntersection: potential kinds for relationship %d=%v", i, potentialKinds)
+		potentialKinds := FindPotentialKinds(kind)
+		debugLog("FindPotentialKindsIntersection: potential kinds for %s=%v", kind, potentialKinds)
 
 		newResult := make(map[string]bool)
-
 		// Keep only kinds that exist in both sets
-		for _, kind := range potentialKinds {
-			if result[kind] {
-				debugLog("FindPotentialKindsIntersection: keeping common kind %s", kind)
-				newResult[kind] = true
+		for _, potentialKind := range potentialKinds {
+			if result[potentialKind] {
+				debugLog("FindPotentialKindsIntersection: keeping common kind %s", potentialKind)
+				newResult[potentialKind] = true
 			}
 		}
-
 		result = newResult
-		debugLog("FindPotentialKindsIntersection: intersection after relationship %d=%v", i, result)
 	}
 
 	// Convert map back to slice

--- a/pkg/core/parser.go
+++ b/pkg/core/parser.go
@@ -982,3 +982,37 @@ func (p *Parser) nextAnonymousVar() string {
 	p.anonymousCounter++
 	return fmt.Sprintf("_anon%d", p.anonymousCounter)
 }
+
+// FindPotentialKinds returns all possible target kinds that could have a relationship with the given source kind
+func FindPotentialKinds(sourceKind string) []string {
+	sourceKind = strings.ToLower(sourceKind)
+	potentialKinds := make(map[string]bool)
+	debugLog("FindPotentialKinds: looking for relationships for sourceKind=%s", sourceKind)
+
+	// Look through all relationship rules
+	rules := GetRelationshipRules()
+	debugLog("FindPotentialKinds: found %d relationship rules", len(rules))
+
+	for _, rule := range rules {
+		debugLog("FindPotentialKinds: checking rule KindA=%s, KindB=%s, Relationship=%s", rule.KindA, rule.KindB, rule.Relationship)
+		// Check if sourceKind matches KindA (direct relationships)
+		if strings.ToLower(rule.KindA) == sourceKind {
+			debugLog("FindPotentialKinds: matched KindA, adding KindB=%s", rule.KindB)
+			potentialKinds[rule.KindB] = true
+		}
+		// Check if sourceKind matches KindB (reverse relationships)
+		if strings.ToLower(rule.KindB) == sourceKind {
+			debugLog("FindPotentialKinds: matched KindB, adding KindA=%s", rule.KindA)
+			potentialKinds[rule.KindA] = true
+		}
+	}
+
+	// Convert map to slice
+	var result []string
+	for kind := range potentialKinds {
+		result = append(result, kind)
+	}
+	debugLog("FindPotentialKinds: final result for %s = %v", sourceKind, result)
+
+	return result
+}

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/json"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -1397,59 +1396,6 @@ func TestParserErrors(t *testing.T) {
 			t.Logf("Got error: %v", err)
 			if !strings.Contains(err.Error(), tt.contains) {
 				t.Errorf("ParseQuery() error = %v, want error containing %q", err, tt.contains)
-			}
-		})
-	}
-}
-
-func TestFindPotentialKinds(t *testing.T) {
-	LogLevel = "debug"
-	tests := []struct {
-		name       string
-		sourceKind string
-		want       []string
-	}{
-		{
-			name:       "pods to services (hardcoded)",
-			sourceKind: "pods",
-			want:       []string{"cronjobs", "daemonsets", "jobs", "networkpolicies", "poddisruptionbudgets", "replicasets", "services", "statefulsets"},
-		},
-		{
-			name:       "services to pods (reverse)",
-			sourceKind: "services",
-			want:       []string{"daemonsets", "deployments", "endpoints", "ingresses", "mutatingwebhookconfigurations", "pods", "replicasets", "statefulsets", "validatingwebhookconfigurations"},
-		},
-		{
-			name:       "case insensitive - PODS",
-			sourceKind: "PODS",
-			want:       []string{"cronjobs", "daemonsets", "jobs", "networkpolicies", "poddisruptionbudgets", "replicasets", "services", "statefulsets"},
-		},
-		{
-			name:       "non-existent kind",
-			sourceKind: "nonexistentkind",
-			want:       []string{},
-		},
-		{
-			name:       "kind with no relationships",
-			sourceKind: "configmaps",
-			want:       []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FindPotentialKinds(tt.sourceKind)
-			// Sort both slices for consistent comparison
-			sort.Strings(got)
-			sort.Strings(tt.want)
-
-			// Special handling for empty slices
-			if len(got) == 0 && len(tt.want) == 0 {
-				return // Both are empty, test passes
-			}
-
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FindPotentialKinds() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -1036,6 +1036,225 @@ func TestRecursiveParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "partial node patterns",
+			input: "MATCH (p:pod)->(:service)->(x) RETURN x.metadata.name",
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "p",
+									Kind: "pod",
+								},
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "",
+									Kind: "service",
+								},
+								IsAnonymous: true,
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "x",
+									Kind: "",
+								},
+							},
+						},
+						Relationships: []*Relationship{
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "p",
+										Kind: "pod",
+									},
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "",
+										Kind: "service",
+									},
+									IsAnonymous: true,
+								},
+							},
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "",
+										Kind: "service",
+									},
+									IsAnonymous: true,
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "x",
+										Kind: "",
+									},
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "x.metadata.name"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "empty node with relationships",
+			input: "MATCH (p:pod)->()->(:service) RETURN p.metadata.name",
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "p",
+									Kind: "pod",
+								},
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "",
+									Kind: "",
+								},
+								IsAnonymous: true,
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "",
+									Kind: "service",
+								},
+								IsAnonymous: true,
+							},
+						},
+						Relationships: []*Relationship{
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "p",
+										Kind: "pod",
+									},
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "",
+										Kind: "",
+									},
+									IsAnonymous: true,
+								},
+							},
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "",
+										Kind: "",
+									},
+									IsAnonymous: true,
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "",
+										Kind: "service",
+									},
+									IsAnonymous: true,
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "p.metadata.name"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "standalone empty node",
+			input:   "MATCH () RETURN",
+			wantErr: true,
+		},
+		{
+			name:    "standalone kind-only node",
+			input:   "MATCH (:pod) RETURN",
+			wantErr: true,
+		},
+		{
+			name:  "variable-only node with relationships",
+			input: "MATCH (p:pod)->(x)->(s:service) RETURN x.kind",
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "p",
+									Kind: "pod",
+								},
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "x",
+									Kind: "",
+								},
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "s",
+									Kind: "service",
+								},
+							},
+						},
+						Relationships: []*Relationship{
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "p",
+										Kind: "pod",
+									},
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "x",
+										Kind: "",
+									},
+								},
+							},
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "x",
+										Kind: "",
+									},
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "s",
+										Kind: "service",
+									},
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "x.kind"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -1037,7 +1037,7 @@ func TestRecursiveParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "partial node patterns",
+			name:  "partial node patterns with anonymous vars",
 			input: "MATCH (p:pod)->(:service)->(x) RETURN x.metadata.name",
 			want: &Expression{
 				Clauses: []Clause{
@@ -1051,7 +1051,7 @@ func TestRecursiveParser(t *testing.T) {
 							},
 							{
 								ResourceProperties: &ResourceProperties{
-									Name: "",
+									Name: "_anon1",
 									Kind: "service",
 								},
 								IsAnonymous: true,
@@ -1074,7 +1074,7 @@ func TestRecursiveParser(t *testing.T) {
 								},
 								RightNode: &NodePattern{
 									ResourceProperties: &ResourceProperties{
-										Name: "",
+										Name: "_anon1",
 										Kind: "service",
 									},
 									IsAnonymous: true,
@@ -1084,7 +1084,7 @@ func TestRecursiveParser(t *testing.T) {
 								Direction: Right,
 								LeftNode: &NodePattern{
 									ResourceProperties: &ResourceProperties{
-										Name: "",
+										Name: "_anon1",
 										Kind: "service",
 									},
 									IsAnonymous: true,
@@ -1107,8 +1107,8 @@ func TestRecursiveParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "empty node with relationships",
-			input: "MATCH (p:pod)->()->(:service) RETURN p.metadata.name",
+			name:  "multiple anonymous nodes",
+			input: "MATCH (p:pod)->()->()->(:service) RETURN p.metadata.name",
 			want: &Expression{
 				Clauses: []Clause{
 					&MatchClause{
@@ -1121,14 +1121,21 @@ func TestRecursiveParser(t *testing.T) {
 							},
 							{
 								ResourceProperties: &ResourceProperties{
-									Name: "",
+									Name: "_anon1",
 									Kind: "",
 								},
 								IsAnonymous: true,
 							},
 							{
 								ResourceProperties: &ResourceProperties{
-									Name: "",
+									Name: "_anon2",
+									Kind: "",
+								},
+								IsAnonymous: true,
+							},
+							{
+								ResourceProperties: &ResourceProperties{
+									Name: "_anon3",
 									Kind: "service",
 								},
 								IsAnonymous: true,
@@ -1145,7 +1152,7 @@ func TestRecursiveParser(t *testing.T) {
 								},
 								RightNode: &NodePattern{
 									ResourceProperties: &ResourceProperties{
-										Name: "",
+										Name: "_anon1",
 										Kind: "",
 									},
 									IsAnonymous: true,
@@ -1155,14 +1162,31 @@ func TestRecursiveParser(t *testing.T) {
 								Direction: Right,
 								LeftNode: &NodePattern{
 									ResourceProperties: &ResourceProperties{
-										Name: "",
+										Name: "_anon1",
 										Kind: "",
 									},
 									IsAnonymous: true,
 								},
 								RightNode: &NodePattern{
 									ResourceProperties: &ResourceProperties{
-										Name: "",
+										Name: "_anon2",
+										Kind: "",
+									},
+									IsAnonymous: true,
+								},
+							},
+							{
+								Direction: Right,
+								LeftNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "_anon2",
+										Kind: "",
+									},
+									IsAnonymous: true,
+								},
+								RightNode: &NodePattern{
+									ResourceProperties: &ResourceProperties{
+										Name: "_anon3",
 										Kind: "service",
 									},
 									IsAnonymous: true,

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -1396,6 +1397,59 @@ func TestParserErrors(t *testing.T) {
 			t.Logf("Got error: %v", err)
 			if !strings.Contains(err.Error(), tt.contains) {
 				t.Errorf("ParseQuery() error = %v, want error containing %q", err, tt.contains)
+			}
+		})
+	}
+}
+
+func TestFindPotentialKinds(t *testing.T) {
+	LogLevel = "debug"
+	tests := []struct {
+		name       string
+		sourceKind string
+		want       []string
+	}{
+		{
+			name:       "pods to services (hardcoded)",
+			sourceKind: "pods",
+			want:       []string{"cronjobs", "daemonsets", "jobs", "networkpolicies", "poddisruptionbudgets", "replicasets", "services", "statefulsets"},
+		},
+		{
+			name:       "services to pods (reverse)",
+			sourceKind: "services",
+			want:       []string{"daemonsets", "deployments", "endpoints", "ingresses", "mutatingwebhookconfigurations", "pods", "replicasets", "statefulsets", "validatingwebhookconfigurations"},
+		},
+		{
+			name:       "case insensitive - PODS",
+			sourceKind: "PODS",
+			want:       []string{"cronjobs", "daemonsets", "jobs", "networkpolicies", "poddisruptionbudgets", "replicasets", "services", "statefulsets"},
+		},
+		{
+			name:       "non-existent kind",
+			sourceKind: "nonexistentkind",
+			want:       []string{},
+		},
+		{
+			name:       "kind with no relationships",
+			sourceKind: "configmaps",
+			want:       []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindPotentialKinds(tt.sourceKind)
+			// Sort both slices for consistent comparison
+			sort.Strings(got)
+			sort.Strings(tt.want)
+
+			// Special handling for empty slices
+			if len(got) == 0 && len(tt.want) == 0 {
+				return // Both are empty, test passes
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindPotentialKinds() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/core/relationship.go
+++ b/pkg/core/relationship.go
@@ -454,6 +454,7 @@ func FindPotentialKinds(sourceKind string, provider provider.Provider) []string 
 
 // FindPotentialKindsIntersection returns the intersection of possible kinds from multiple relationships
 func FindPotentialKindsIntersection(relationships []*Relationship, provider provider.Provider) []string {
+	logDebug("FindPotentialKindsIntersection: Starting with relationships:", relationships)
 	if len(relationships) == 0 {
 		debugLog("FindPotentialKindsIntersection: no relationships provided")
 		return []string{}
@@ -479,16 +480,18 @@ func FindPotentialKindsIntersection(relationships []*Relationship, provider prov
 	for _, rel := range relationships {
 		if rel.LeftNode.ResourceProperties.Kind != "" {
 			knownKinds[strings.ToLower(rel.LeftNode.ResourceProperties.Kind)] = true
+			logDebug(fmt.Sprintf("FindPotentialKindsIntersection: Found known kind (left): %s", rel.LeftNode.ResourceProperties.Kind))
 		}
 		if rel.RightNode.ResourceProperties.Kind != "" {
 			knownKinds[strings.ToLower(rel.RightNode.ResourceProperties.Kind)] = true
+			logDebug(fmt.Sprintf("FindPotentialKindsIntersection: Found known kind (right): %s", rel.RightNode.ResourceProperties.Kind))
 		}
 	}
-	debugLog("FindPotentialKindsIntersection: found known kinds=%v", knownKinds)
+	logDebug(fmt.Sprintf("FindPotentialKindsIntersection: All known kinds: %v", knownKinds))
 
 	// If no known kinds, return empty
 	if len(knownKinds) == 0 {
-		debugLog("FindPotentialKindsIntersection: no known kinds found")
+		logDebug("FindPotentialKindsIntersection: no known kinds found")
 		return []string{}
 	}
 
@@ -500,10 +503,11 @@ func FindPotentialKindsIntersection(relationships []*Relationship, provider prov
 	}
 
 	result := make(map[string]bool)
-	for _, kind := range FindPotentialKinds(firstKnownKind, provider) {
+	initialPotentialKinds := FindPotentialKinds(firstKnownKind, provider)
+	logDebug(fmt.Sprintf("FindPotentialKindsIntersection: Initial potential kinds from %s: %v", firstKnownKind, initialPotentialKinds))
+	for _, kind := range initialPotentialKinds {
 		result[kind] = true
 	}
-	debugLog("FindPotentialKindsIntersection: initial potential kinds from %s=%v", firstKnownKind, result)
 
 	// For each additional known kind, intersect with its potential kinds
 	for kind := range knownKinds {
@@ -512,13 +516,13 @@ func FindPotentialKindsIntersection(relationships []*Relationship, provider prov
 		}
 
 		potentialKinds := FindPotentialKinds(kind, provider)
-		debugLog("FindPotentialKindsIntersection: potential kinds for %s=%v", kind, potentialKinds)
+		logDebug(fmt.Sprintf("FindPotentialKindsIntersection: Potential kinds for %s: %v", kind, potentialKinds))
 
 		newResult := make(map[string]bool)
 		// Keep only kinds that exist in both sets
 		for _, potentialKind := range potentialKinds {
 			if result[potentialKind] {
-				debugLog("FindPotentialKindsIntersection: keeping common kind %s", potentialKind)
+				logDebug(fmt.Sprintf("FindPotentialKindsIntersection: Keeping common kind %s", potentialKind))
 				newResult[potentialKind] = true
 			}
 		}
@@ -531,7 +535,7 @@ func FindPotentialKindsIntersection(relationships []*Relationship, provider prov
 		kinds = append(kinds, kind)
 	}
 	sort.Strings(kinds) // Sort for consistent results
-	debugLog("FindPotentialKindsIntersection: final result=%v", kinds)
+	logDebug(fmt.Sprintf("FindPotentialKindsIntersection: Final result=%v", kinds))
 	return kinds
 }
 

--- a/pkg/core/relationship.go
+++ b/pkg/core/relationship.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -322,4 +323,122 @@ func GetRelationships() map[string][]string {
 	defer relationshipsMutex.RUnlock()
 
 	return relationships
+}
+
+// FindPotentialKinds returns all possible target kinds that could have a relationship with the given source kind
+func FindPotentialKinds(sourceKind string) []string {
+	sourceKind = strings.ToLower(sourceKind)
+	potentialKinds := make(map[string]bool)
+	debugLog("FindPotentialKinds: looking for relationships for sourceKind=%s", sourceKind)
+
+	// Look through all relationship rules
+	rules := GetRelationshipRules()
+	debugLog("FindPotentialKinds: found %d relationship rules", len(rules))
+
+	for _, rule := range rules {
+		debugLog("FindPotentialKinds: checking rule KindA=%s, KindB=%s, Relationship=%s", rule.KindA, rule.KindB, rule.Relationship)
+
+		// If sourceKind is KindB, we want KindA (what can connect to sourceKind)
+		if strings.ToLower(rule.KindB) == sourceKind || strings.ToLower(rule.KindB) == sourceKind+"s" {
+			debugLog("FindPotentialKinds: matched KindB, adding KindA=%s", rule.KindA)
+			potentialKinds[rule.KindA] = true
+		}
+		// If sourceKind is KindA, we want KindB (what sourceKind can connect to)
+		if strings.ToLower(rule.KindA) == sourceKind || strings.ToLower(rule.KindA) == sourceKind+"s" {
+			debugLog("FindPotentialKinds: matched KindA, adding KindB=%s", rule.KindB)
+			potentialKinds[rule.KindB] = true
+		}
+	}
+
+	// Convert map to slice
+	var result []string
+	for kind := range potentialKinds {
+		result = append(result, kind)
+	}
+	sort.Strings(result) // Sort for consistent results
+	debugLog("FindPotentialKinds: final result for %s = %v", sourceKind, result)
+	return result
+}
+
+// FindPotentialKindsIntersection returns the intersection of possible kinds from multiple relationships
+func FindPotentialKindsIntersection(relationships []*Relationship) []string {
+	if len(relationships) == 0 {
+		debugLog("FindPotentialKindsIntersection: no relationships provided")
+		return []string{}
+	}
+
+	// Check if there are any unknown kinds that need resolution
+	hasUnknownKind := false
+	for _, rel := range relationships {
+		if rel.LeftNode.ResourceProperties.Kind == "" || rel.RightNode.ResourceProperties.Kind == "" {
+			hasUnknownKind = true
+			break
+		}
+	}
+
+	// If all kinds are known, return empty slice
+	if !hasUnknownKind {
+		debugLog("FindPotentialKindsIntersection: all kinds are known")
+		return []string{}
+	}
+
+	// Find all known kinds in the relationships
+	knownKinds := make(map[string]bool)
+	for _, rel := range relationships {
+		if rel.LeftNode.ResourceProperties.Kind != "" {
+			knownKinds[strings.ToLower(rel.LeftNode.ResourceProperties.Kind)] = true
+		}
+		if rel.RightNode.ResourceProperties.Kind != "" {
+			knownKinds[strings.ToLower(rel.RightNode.ResourceProperties.Kind)] = true
+		}
+	}
+	debugLog("FindPotentialKindsIntersection: found known kinds=%v", knownKinds)
+
+	// If no known kinds, return empty
+	if len(knownKinds) == 0 {
+		debugLog("FindPotentialKindsIntersection: no known kinds found")
+		return []string{}
+	}
+
+	// Initialize result with potential kinds from first known kind
+	var firstKnownKind string
+	for kind := range knownKinds {
+		firstKnownKind = kind
+		break
+	}
+
+	result := make(map[string]bool)
+	for _, kind := range FindPotentialKinds(firstKnownKind) {
+		result[kind] = true
+	}
+	debugLog("FindPotentialKindsIntersection: initial potential kinds from %s=%v", firstKnownKind, result)
+
+	// For each additional known kind, intersect with its potential kinds
+	for kind := range knownKinds {
+		if kind == firstKnownKind {
+			continue
+		}
+
+		potentialKinds := FindPotentialKinds(kind)
+		debugLog("FindPotentialKindsIntersection: potential kinds for %s=%v", kind, potentialKinds)
+
+		newResult := make(map[string]bool)
+		// Keep only kinds that exist in both sets
+		for _, potentialKind := range potentialKinds {
+			if result[potentialKind] {
+				debugLog("FindPotentialKindsIntersection: keeping common kind %s", potentialKind)
+				newResult[potentialKind] = true
+			}
+		}
+		result = newResult
+	}
+
+	// Convert map back to slice
+	var kinds []string
+	for kind := range result {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds) // Sort for consistent results
+	debugLog("FindPotentialKindsIntersection: final result=%v", kinds)
+	return kinds
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -68,6 +68,7 @@ type ReturnItem struct {
 // NodePattern represents a node pattern in a query
 type NodePattern struct {
 	ResourceProperties *ResourceProperties
+	IsAnonymous        bool // Indicates if this is an anonymous node (no variable name)
 }
 
 // ResourceProperties represents the properties of a resource


### PR DESCRIPTION
# Partial Node Patterns
This PR introduces a much desired language feature, the ability to use **anonymous nodes** (nodes without a variable name such as `(:configMap)`) and **kindless nodes** (nodes without a kind label such as `(x)`) - as well as nodes that are both anonymous AND kindless, (simply `()`).

## Anonymous Nodes
Anonymous nodes allow adding nodes in a node pattern where no data is to be returned/patched/deleted in a subsequent clause - and therefore the variable name is redundant. 
For example:
```graphql
MATCH (cm:ConfigMap)->(:Pod) RETURN cm
```
Will return all confimaps that are attached to pods, where we don't care about returning these pods later.

Under the hood, Cyphernetes will assign a variable name for the node behind the scenes. This allows for leaner queries without redundancy.

## Kindless Nodes
Kindless nodes allow for exciting new possibilities unlocked by the power of Cypher. By using a kindless node in a query, we're able to discover all resources that are related to a selected node:
<img width="1219" alt="Screenshot 2025-01-28 at 15 20 25" src="https://github.com/user-attachments/assets/47dbea39-e563-4a14-89cd-0569964b2d0c" />

Nodes may be both Kindless and Anonymous, and used in a relationship chain as usual.
This allows discovering related resources that are possibly connected by one or more resource kinds:
<img width="1221" alt="Screenshot 2025-01-28 at 15 25 57" src="https://github.com/user-attachments/assets/0b77952b-8168-4152-83d1-5f29259288d6" />

Under the hood, Cyphernetes will resolve all possible kinds for the kindless nodes, then rewrites the query and reevaluates it in a manner that's transparent to the user, for example:
```graphql
MATCH (d:Deployment)->(x) RETURN x.kind
```
Gets expanded to:
```graphql
MATCH (d__exp__0:Deployment)->(p__exp__0:Pod),
      (d__exp__1:Deployment)->(rs__exp__0:ReplicaSet) ...
RETURN p__exp__0.kind, rs__exp__0.kind ...
```

This query expansion technique allows the underlying, tested Cyphernetes mechanics to remain in place while opening up  exciting new possibilities.

---

This PR forms a base for future language development including some highly sought out features like using node patterns in WHERE and DELETE clauses.