### PR TITLE
Fix escape dots in jsonPaths

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -276,6 +276,7 @@ RETURN d.metadata.annotations.meta\.cyphernet\.es/foo-bar
 * `=` - equal to
 * `!=` - not equal to
 * `<` - less than
+* `>` - greater than
 * `<=` - less than or equal to
 * `>=` - greater than or equal to
 * `=~` - regex matching

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -245,11 +245,37 @@ RETURN d.spec.replicas
 }
 ```
 
+### Escaping Dots in JSONPaths
+
+Cyphernetes supports escaping dots in JSONPaths using a backslash. This is useful when querying resources that have dots in their field names.
+
+```graphql
+MATCH (d:Deployment {name: "nginx-internal"})
+WHERE d.metadata.annotations.meta\.cyphernet\.es/foo-bar = "baz"
+RETURN d.metadata.annotations.meta\.cyphernet\.es/foo-bar
+```
+
+(output)
+
+```json
+{
+  "d": [
+    {
+      "name": "nginx-internal",
+      "metadata": {
+        "annotations": {
+          "meta.cyphernet.es/foo-bar": "baz"
+        }
+      }
+    }
+  ]
+}
+```
+
 `WHERE` clauses support the following operators:
 * `=` - equal to
 * `!=` - not equal to
 * `<` - less than
-* `>` - greater than
 * `<=` - less than or equal to
 * `>=` - greater than or equal to
 * `=~` - regex matching

--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -614,12 +614,21 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 					return *results, fmt.Errorf("node identifier %s not found in return clause", nodeId)
 				}
 
-				pathParts := strings.Split(item.JsonPath, ".")[1:]
-				pathStr := "$." + strings.Join(pathParts, ".")
-
-				if pathStr == "$." {
-					pathStr = "$"
+				// Transform path to jsonpath format
+				path := strings.Replace(item.JsonPath, nodeId+".", "$.", 1)
+				if path == "$." {
+					path = "$"
 				}
+
+				// Compile and fix the path
+				if !strings.Contains(path, ".") {
+					path = "$"
+				}
+				compiledPath, err := jsonpath.Compile(path)
+				if err != nil {
+					return *results, fmt.Errorf("error compiling path %s: %v", path, err)
+				}
+				compiledPath = fixCompiledPath(compiledPath)
 
 				if results.Data[nodeId] == nil {
 					results.Data[nodeId] = []interface{}{}
@@ -635,7 +644,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 					}
 					currentMap := results.Data[nodeId].([]interface{})[idx].(map[string]interface{})
 
-					result, err := jsonpath.JsonPathLookup(resource, pathStr)
+					result, err := compiledPath.Lookup(resource)
 					if err != nil {
 						logDebug("Path not found:", item.JsonPath)
 						result = nil
@@ -662,75 +671,40 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 									v2 = v2.Elem()
 								}
 
-								isCPUResource := strings.Contains(pathStr, "resources.limits.cpu") || strings.Contains(pathStr, "resources.requests.cpu")
-								isMemoryResource := strings.Contains(pathStr, "resources.limits.memory") || strings.Contains(pathStr, "resources.requests.memory")
+								isCPUResource := strings.Contains(path, "resources.limits.cpu") || strings.Contains(path, "resources.requests.cpu")
+								isMemoryResource := strings.Contains(path, "resources.limits.memory") || strings.Contains(path, "resources.requests.memory")
 
 								switch v1.Kind() {
 								case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 									aggregateResult = v1.Int() + v2.Int()
-								case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-									aggregateResult = v1.Uint() + v2.Uint()
 								case reflect.Float32, reflect.Float64:
 									aggregateResult = v1.Float() + v2.Float()
 								case reflect.String:
 									if isCPUResource {
-										v1Cpu, err := convertToMilliCPU(v1.String())
+										// Convert CPU strings to millicores
+										cpu1, err := convertToMilliCPU(v1.String())
 										if err != nil {
-											return *results, fmt.Errorf("error processing cpu resources value: %v", err)
+											return *results, err
 										}
-										v2Cpu, err := convertToMilliCPU(v2.String())
+										cpu2, err := convertToMilliCPU(v2.String())
 										if err != nil {
-											return *results, fmt.Errorf("error processing cpu resources value: %v", err)
+											return *results, err
 										}
-
-										aggregateResult = convertMilliCPUToStandard(v1Cpu + v2Cpu)
+										aggregateResult = convertMilliCPUToStandard(cpu1 + cpu2)
 									} else if isMemoryResource {
-										v1Mem, err := convertMemoryToBytes(v1.String())
+										// Convert memory strings to bytes
+										mem1, err := convertMemoryToBytes(v1.String())
 										if err != nil {
-											return *results, fmt.Errorf("error processing memory resources value: %v", err)
+											return *results, err
 										}
-										v2Mem, err := convertMemoryToBytes(v2.String())
+										mem2, err := convertMemoryToBytes(v2.String())
 										if err != nil {
-											return *results, fmt.Errorf("error processing memory resources value: %v", err)
+											return *results, err
 										}
-
-										aggregateResult = convertBytesToMemory(v1Mem + v2Mem)
-									}
-								case reflect.Slice:
-									v1Strs, err := convertToStringSlice(v1)
-									if err != nil {
-										return *results, fmt.Errorf("error converting v1 to string slice: %v", err)
-									}
-
-									v2Strs, err := convertToStringSlice(v2)
-									if err != nil {
-										return *results, fmt.Errorf("error converting v2 to string slice: %v", err)
-									}
-
-									if isCPUResource {
-										v1CpuSum, err := sumMilliCPU(v1Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v1 cpu value: %v", err)
-										}
-
-										v2CpuSum, err := sumMilliCPU(v2Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v2 cpu value: %v", err)
-										}
-
-										aggregateResult = []string{convertMilliCPUToStandard(v1CpuSum + v2CpuSum)}
-									} else if isMemoryResource {
-										v1MemSum, err := sumMemoryBytes(v1Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v1 memory value: %v", err)
-										}
-
-										v2MemSum, err := sumMemoryBytes(v2Strs)
-										if err != nil {
-											return *results, fmt.Errorf("error processing v2 memory value: %v", err)
-										}
-
-										aggregateResult = []string{convertBytesToMemory(v1MemSum + v2MemSum)}
+										aggregateResult = convertBytesToMemory(mem1 + mem2)
+									} else {
+										// Handle unsupported types or error out
+										return *results, fmt.Errorf("unsupported type for SUM: %v", v1.Kind())
 									}
 								default:
 									// Handle unsupported types or error out
@@ -743,20 +717,12 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 					if item.Aggregate == "" {
 						key := item.Alias
 						if key == "" {
-							if len(pathParts) == 1 {
-								key = pathParts[0]
-							} else if len(pathParts) > 1 {
-								nestedMap := currentMap
-								for i := 0; i < len(pathParts)-1; i++ {
-									if _, exists := nestedMap[pathParts[i]]; !exists {
-										nestedMap[pathParts[i]] = make(map[string]interface{})
-									}
-									nestedMap = nestedMap[pathParts[i]].(map[string]interface{})
-								}
-								nestedMap[pathParts[len(pathParts)-1]] = result
-								continue
-							} else {
+							// Use the last step from the compiled path as the key
+							if len(compiledPath.Steps) == 0 {
 								key = "$"
+							} else {
+								lastStep := compiledPath.Steps[len(compiledPath.Steps)-1]
+								key = lastStep.Key
 							}
 						}
 						currentMap[key] = result
@@ -770,7 +736,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 					key := item.Alias
 					if key == "" {
-						key = strings.ToLower(item.Aggregate) + ":" + nodeId + "." + strings.Replace(pathStr, "$.", "", 1)
+						key = strings.ToLower(item.Aggregate) + ":" + nodeId + "." + strings.TrimPrefix(path, "$.")
 					}
 
 					if slice, ok := aggregateResult.([]interface{}); ok && len(slice) == 0 {
@@ -1954,6 +1920,22 @@ func (q *QueryExecutor) Provider() provider.Provider {
 	return q.provider
 }
 
+func fixCompiledPath(compiledPath *jsonpath.Compiled) *jsonpath.Compiled {
+	i := 0
+	for i < len(compiledPath.Steps) {
+		step := compiledPath.Steps[i]
+		if strings.HasSuffix(step.Key, "\\") && i+1 < len(compiledPath.Steps) {
+			nextStep := compiledPath.Steps[i+1]
+			step.Key = step.Key[:len(step.Key)-1] + "." + nextStep.Key
+			compiledPath.Steps[i] = step
+			compiledPath.Steps = append(compiledPath.Steps[:i+1], compiledPath.Steps[i+2:]...)
+		} else {
+			i++
+		}
+	}
+	return compiledPath
+}
+
 func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*KeyValuePair) (err error) {
 	namespace := Namespace
 
@@ -2044,6 +2026,16 @@ func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*KeyValue
 					path := filter.Key
 					path = strings.Replace(path, resultMapKey+".", "$.", 1)
 
+					// Compile and fix the path
+					compiledPath, err := jsonpath.Compile(path)
+					if err != nil {
+						keep = false
+						break
+					}
+					compiledPath = fixCompiledPath(compiledPath)
+
+					logDebug("Looking up path: %s in resource: %+v", path, resource)
+
 					// If path contains wildcards, we need special handling
 					if strings.Contains(path, "[*]") {
 						keep = evaluateWildcardPath(resource, path, filter.Value, filter.Operator)
@@ -2051,8 +2043,8 @@ func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*KeyValue
 							keep = !keep
 						}
 					} else {
-						// Regular path handling
-						value, err := jsonpath.JsonPathLookup(resource, path)
+						// Regular path handling using the fixed compiled path
+						value, err := compiledPath.Lookup(resource)
 						if err != nil {
 							keep = false
 							break

--- a/pkg/core/lexer_test.go
+++ b/pkg/core/lexer_test.go
@@ -280,6 +280,20 @@ func TestLexer(t *testing.T) {
 				{Type: EOF, Literal: ""},
 			},
 		},
+		{
+			name:  "escaped dots in json paths",
+			input: `d.metadata.annotations.meta\.helm\.sh/release-name`,
+			expected: []Token{
+				{Type: IDENT, Literal: "d"},
+				{Type: DOT, Literal: "."},
+				{Type: IDENT, Literal: "metadata"},
+				{Type: DOT, Literal: "."},
+				{Type: IDENT, Literal: "annotations"},
+				{Type: DOT, Literal: "."},
+				{Type: IDENT, Literal: "meta\\.helm\\.sh/release-name"},
+				{Type: EOF, Literal: ""},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -1324,6 +1324,27 @@ func TestRecursiveParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "match with escaped dots in json paths",
+			input: `MATCH (d:Deployment) WHERE d.metadata.annotations.meta\.helm\.sh/release-name = "my-app" RETURN d.metadata.annotations.meta\.helm\.sh/release-name`,
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{ResourceProperties: &ResourceProperties{Name: "d", Kind: "Deployment"}},
+						},
+						ExtraFilters: []*KeyValuePair{
+							{Key: "d.metadata.annotations.meta\\.helm\\.sh/release-name", Value: "my-app", Operator: "EQUALS"},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "d.metadata.annotations.meta\\.helm\\.sh/release-name"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This fixes a regression in the new parser version that incorrectly handled escaped dots in jsonPaths i.e.:
```graphql
MATCH (d:deploy)->(p:pod) WHERE d.metadata.annotations.meta\.cyphernet\.es/foo = "bar" RETURN d.metadata.annotations.meta\.cyphernet\.es/foo
```

It fixes it for both WHERE and RETURN clauses.