### PR TITLE
Add resultMap+cache mutex protection

### DIFF
--- a/pkg/core/k8s_query.go
+++ b/pkg/core/k8s_query.go
@@ -2135,18 +2135,12 @@ func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*KeyValue
 		resultCache[cacheKey] = filtered
 		resultMap[n.ResourceProperties.Name] = filtered
 		resultMapMutex.Unlock()
-
 	} else {
+		// If we found it in cache, just copy to resultMap
 		resultMapMutex.Lock()
-		resultMap[n.ResourceProperties.Name] = resultCache[cacheKey]
+		resultMap[n.ResourceProperties.Name] = cachedResult
 		resultMapMutex.Unlock()
-
 	}
-
-	// Lock for writing to resultMap
-	resultMapMutex.Lock()
-	resultMap[n.ResourceProperties.Name] = cachedResult
-	resultMapMutex.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
During regular [operator e2e testing](https://github.com/AvitalTamir/cyphernetes/actions/runs/13228990928/job/36923496810) we came across a race condition while writing to the resultMap.
This PR adds missing mutex locks around this write, as well as a similar missing protection around writing to the result cache.