### PR TITLE
Graph Patterns in WHERE Clause

### DIFF
--- a/pkg/core/e2e/e2e_test.go
+++ b/pkg/core/e2e/e2e_test.go
@@ -626,7 +626,7 @@ var _ = Describe("Cyphernetes E2E", func() {
 			executor, err := core.NewQueryExecutor(provider)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Query to find pods owned by the deployment through a replicaset
+			// Query to find deployments that do not have a replicaset that has a pod
 			ast, err := core.ParseQuery(`
 				MATCH (d:Deployment)
 				WHERE NOT (d)->(:ReplicaSet)->(:Pod)
@@ -643,7 +643,7 @@ var _ = Describe("Cyphernetes E2E", func() {
 			Expect(ok).To(BeTrue(), "Expected result.Data['d'] to be a slice")
 			Expect(deployments).To(HaveLen(1), "Expected a single deployment")
 
-			// Query to find pods owned by the deployment through a replicaset
+			// Query to find deployments that have a replicaset that has a pod
 			ast, err = core.ParseQuery(`
 				MATCH (d:Deployment)
 				WHERE (d)->(:ReplicaSet)->(:Pod)

--- a/pkg/core/e2e/e2e_test.go
+++ b/pkg/core/e2e/e2e_test.go
@@ -3050,6 +3050,403 @@ var _ = Describe("Cyphernetes E2E", func() {
 		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
 		Expect(k8sClient.Delete(ctx, testService)).Should(Succeed())
 	})
+
+	It("Should handle complex relationship patterns correctly", func() {
+		By("Creating test resources")
+		testDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-complex",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"app": "test-complex",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "test-complex",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "test-complex",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testDeployment)).Should(Succeed())
+
+		// Wait for deployment to be ready
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace,
+				Name:      "test-deployment-complex",
+			}, &appsv1.Deployment{})
+		}, timeout, interval).Should(Succeed())
+
+		By("Testing complex relationship patterns")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test pattern with multiple conditions
+		ast, err := core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE (d)->(:ReplicaSet {app: "test-complex"})->(:Pod)
+			AND d.metadata.name = "test-deployment-complex"
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		// Test negated pattern with multiple relationships
+		ast, err = core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE NOT (d)->(:ReplicaSet)->(:Pod {app: "non-existent"})
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err = executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		By("Cleaning up")
+		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
+	})
+
+	It("Should handle pattern matching with array indexing", func() {
+		By("Creating test resources")
+		testDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-array",
+				Namespace: testNamespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "test-array",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+							{
+								Name:  "sidecar",
+								Image: "sidecar:latest",
+							},
+						},
+					},
+				},
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "test-array",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testDeployment)).Should(Succeed())
+
+		By("Testing array indexing in patterns")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test pattern with array indexing
+		ast, err := core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE d.spec.template.spec.containers[1].name = "sidecar"
+			AND NOT (d)->(:ReplicaSet)->(:Pod {app: "test-array"})
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		By("Cleaning up")
+		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
+	})
+
+	It("Should handle pattern matching with label selectors", func() {
+		By("Creating test resources")
+		testDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-labels",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"app":         "test-labels",
+					"environment": "test",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "test-labels",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app":         "test-labels",
+							"environment": "test",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testDeployment)).Should(Succeed())
+
+		By("Testing pattern matching with label selectors")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test pattern with label selector matching
+		ast, err := core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE (d)->(:ReplicaSet {app: "test-labels", environment: "test"})->(:Pod)
+			AND d.metadata.labels.environment = "test"
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		By("Cleaning up")
+		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
+	})
+
+	It("Should handle pattern matching with reference node properties", func() {
+		By("Creating test resources")
+		testDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-ref-props",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"app":         "test-ref-props",
+					"environment": "test",
+					"tier":        "backend",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":         "test-ref-props",
+						"environment": "test",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app":         "test-ref-props",
+							"environment": "test",
+							"tier":        "backend",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testDeployment)).Should(Succeed())
+
+		// Wait for deployment to be ready
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace,
+				Name:      "test-deployment-ref-props",
+			}, &appsv1.Deployment{})
+		}, timeout, interval).Should(Succeed())
+
+		By("Testing pattern matching with reference node properties")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test pattern where reference node has properties
+		ast, err := core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE d.metadata.labels.tier = "backend"
+			AND (d)->(:ReplicaSet)->(:Pod)
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		// Test negated pattern with reference node properties
+		ast, err = core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE d.metadata.labels.tier = "backend"
+			AND NOT (d)->(:ReplicaSet {tier: "frontend"})->(:Pod)
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err = executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		// Test pattern with multiple property conditions
+		ast, err = core.ParseQuery(`
+			MATCH (d:Deployment)
+			WHERE d.metadata.labels.tier = "backend"
+			AND d.metadata.labels.environment = "test"
+			AND (d)->(:ReplicaSet {app: "test-ref-props"})->(:Pod)
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err = executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		By("Cleaning up")
+		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
+	})
+
+	It("Should handle pattern matching with reference node MATCH properties", func() {
+		By("Creating test resources")
+		testDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-match-props",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"app":         "test-match",
+					"environment": "test",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":         "test-match",
+						"environment": "test",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app":         "test-match",
+							"environment": "test",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, testDeployment)).Should(Succeed())
+
+		// Wait for deployment to be ready
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace,
+				Name:      "test-deployment-match-props",
+			}, &appsv1.Deployment{})
+		}, timeout, interval).Should(Succeed())
+
+		By("Testing pattern matching with properties in MATCH clause")
+		provider, err := apiserver.NewAPIServerProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		executor, err := core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test pattern with properties in MATCH clause
+		ast, err := core.ParseQuery(`
+			MATCH (d:Deployment {app: "test-match"})
+			WHERE NOT (d)->(:ReplicaSet)->(:Pod)
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		// Test with both MATCH properties and relationship properties
+		ast, err = core.ParseQuery(`
+			MATCH (d:Deployment {app: "test-match", environment: "test"})
+			WHERE NOT (d)->(:ReplicaSet {app: "non-existent"})->(:Pod)
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err = executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		// Test with shorthand label properties in MATCH
+		ast, err = core.ParseQuery(`
+			MATCH (d:Deployment {app: "test-match"})
+			WHERE NOT (d)->(:ReplicaSet)->(:Pod {app: "test-match"})
+			RETURN d
+		`)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err = executor.Execute(ast, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Data).To(HaveKey("d"))
+
+		By("Cleaning up")
+		Expect(k8sClient.Delete(ctx, testDeployment)).Should(Succeed())
+	})
 })
 
 var _ = Describe("Ambiguous Resource Kinds", func() {

--- a/pkg/core/e2e/e2e_test.go
+++ b/pkg/core/e2e/e2e_test.go
@@ -642,6 +642,22 @@ var _ = Describe("Cyphernetes E2E", func() {
 			deployments, ok := result.Data["d"].([]interface{})
 			Expect(ok).To(BeTrue(), "Expected result.Data['d'] to be a slice")
 			Expect(deployments).To(HaveLen(1), "Expected a single deployment")
+
+			// Query to find pods owned by the deployment through a replicaset
+			ast, err = core.ParseQuery(`
+				MATCH (d:Deployment)
+				WHERE (d)->(:ReplicaSet)->(:Pod)
+				RETURN d
+			`)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err = executor.Execute(ast, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Data).To(HaveKey("d"))
+			deployments, ok = result.Data["d"].([]interface{})
+			Expect(ok).To(BeTrue(), "Expected result.Data['d'] to be a slice")
+			Expect(deployments).To(BeEmpty(), "Expected no deployments")
 		})
 
 		It("Should handle invalid pattern matching queries correctly", func() {

--- a/pkg/core/e2e/e2e_test.go
+++ b/pkg/core/e2e/e2e_test.go
@@ -586,7 +586,7 @@ var _ = Describe("Cyphernetes E2E", func() {
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: ptr.To(int32(1)),
+					Replicas: ptr.To(int32(0)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app": "pattern-test",
@@ -629,8 +629,7 @@ var _ = Describe("Cyphernetes E2E", func() {
 			// Query to find pods owned by the deployment through a replicaset
 			ast, err := core.ParseQuery(`
 				MATCH (d:Deployment)
-				WHERE d.metadata.name = "test-deployment-pattern" AND
-					NOT (d)->(:ReplicaSet)->(:Pod)
+				WHERE NOT (d)->(:ReplicaSet)->(:Pod)
 				RETURN d
 			`)
 			Expect(err).NotTo(HaveOccurred())
@@ -642,7 +641,7 @@ var _ = Describe("Cyphernetes E2E", func() {
 			Expect(result.Data).To(HaveKey("d"))
 			deployments, ok := result.Data["d"].([]interface{})
 			Expect(ok).To(BeTrue(), "Expected result.Data['d'] to be a slice")
-			Expect(deployments).To(BeEmpty(), "Expected no deployments")
+			Expect(deployments).To(HaveLen(1), "Expected a single deployment")
 		})
 
 		It("Should handle invalid pattern matching queries correctly", func() {

--- a/pkg/core/parser.go
+++ b/pkg/core/parser.go
@@ -13,6 +13,7 @@ type Parser struct {
 	pos              int
 	inCreate         bool
 	anonymousCounter int
+	matchVariables   map[string]*NodePattern // Track variables defined in MATCH clause
 }
 
 func NewRecursiveParser(input string) *Parser {
@@ -20,6 +21,7 @@ func NewRecursiveParser(input string) *Parser {
 	return &Parser{
 		lexer:            lexer,
 		anonymousCounter: 0,
+		matchVariables:   make(map[string]*NodePattern),
 	}
 }
 
@@ -183,6 +185,9 @@ func (p *Parser) parseMatchClause() (*MatchClause, error) {
 		return nil, err
 	}
 
+	// Track variables from the MATCH clause
+	p.trackMatchVariables(nodeRels.Nodes)
+
 	// Validate that we don't have standalone anonymous nodes
 	if len(nodeRels.Nodes) == 1 && len(nodeRels.Relationships) == 0 {
 		node := nodeRels.Nodes[0]
@@ -191,7 +196,7 @@ func (p *Parser) parseMatchClause() (*MatchClause, error) {
 		}
 	}
 
-	var filters []*KeyValuePair
+	var filters []*Filter
 	if p.current.Type == WHERE {
 		p.advance()
 		filters, err = p.parseKeyValuePairs()
@@ -531,12 +536,14 @@ func (p *Parser) parseSetClause() (*SetClause, error) {
 	}
 	p.advance()
 
-	pairs, err := p.parseKeyValuePairs()
+	filters, err := p.parseKeyValuePairs()
 	if err != nil {
 		return nil, err
 	}
 
-	return &SetClause{KeyValuePairs: pairs}, nil
+	// Extract only KeyValuePairs for SET clause
+	kvPairs := extractKeyValuePairs(filters)
+	return &SetClause{KeyValuePairs: kvPairs}, nil
 }
 
 // parseDeleteClause parses: DELETE NodeIds
@@ -761,75 +768,102 @@ func (p *Parser) parseProperties() (*Properties, error) {
 }
 
 // parseKeyValuePairs parses a list of key-value pairs with operators
-func (p *Parser) parseKeyValuePairs() ([]*KeyValuePair, error) {
-	var pairs []*KeyValuePair
+func (p *Parser) parseKeyValuePairs() ([]*Filter, error) {
+	var filters []*Filter
 
 	for {
-		// Check for NOT token before the identifier
+		// Check for NOT token before the pattern
 		isNegated := false
 		if p.current.Type == NOT {
 			isNegated = true
 			p.advance()
 		}
 
-		if p.current.Type != IDENT {
-			return nil, fmt.Errorf("expected identifier, got \"%v\"", p.current.Literal)
-		}
-		var path strings.Builder
-		path.WriteString(p.current.Literal)
-		p.advance()
+		// Check if this is a submatch pattern
+		if p.current.Type == LPAREN {
+			nodeRels, err := p.parseNodeRelationshipList()
+			if err != nil {
+				return nil, err
+			}
 
-		for {
-			if p.current.Type == DOT {
-				p.advance()
-				path.WriteString(".")
-				if p.current.Type != IDENT {
-					return nil, fmt.Errorf("expected identifier after dot, got \"%v\"", p.current.Literal)
-				}
-				path.WriteString(p.current.Literal)
-				p.advance()
-			} else if p.current.Type == LBRACKET {
-				p.advance()
-				path.WriteString("[")
-				// Add support for wildcard
-				if p.current.Type == ILLEGAL && p.current.Literal == "*" {
-					path.WriteString("*")
+			// Validate the submatch pattern
+			err = p.validateSubmatchPattern(nodeRels.Nodes, nodeRels.Relationships)
+			if err != nil {
+				return nil, err
+			}
+
+			filters = append(filters, &Filter{
+				Type: "SubMatch",
+				SubMatch: &SubMatch{
+					IsNegated:     isNegated,
+					Nodes:         nodeRels.Nodes,
+					Relationships: nodeRels.Relationships,
+				},
+			})
+		} else {
+			// Handle regular key-value pair
+			if p.current.Type != IDENT {
+				return nil, fmt.Errorf("expected identifier or pattern, got \"%v\"", p.current.Literal)
+			}
+			var path strings.Builder
+			path.WriteString(p.current.Literal)
+			p.advance()
+
+			for {
+				if p.current.Type == DOT {
 					p.advance()
-				} else if p.current.Type == NUMBER {
+					path.WriteString(".")
+					if p.current.Type != IDENT {
+						return nil, fmt.Errorf("expected identifier after dot, got \"%v\"", p.current.Literal)
+					}
 					path.WriteString(p.current.Literal)
 					p.advance()
+				} else if p.current.Type == LBRACKET {
+					p.advance()
+					path.WriteString("[")
+					// Add support for wildcard
+					if p.current.Type == ILLEGAL && p.current.Literal == "*" {
+						path.WriteString("*")
+						p.advance()
+					} else if p.current.Type == NUMBER {
+						path.WriteString(p.current.Literal)
+						p.advance()
+					} else {
+						return nil, fmt.Errorf("expected number or * in array index, got \"%v\"", p.current.Literal)
+					}
+					if p.current.Type != RBRACKET {
+						return nil, fmt.Errorf("expected closing bracket, got \"%v\"", p.current.Literal)
+					}
+					path.WriteString("]")
+					p.advance()
+					if p.current.Type == DOT {
+						continue
+					}
 				} else {
-					return nil, fmt.Errorf("expected number or * in array index, got \"%v\"", p.current.Literal)
+					break
 				}
-				if p.current.Type != RBRACKET {
-					return nil, fmt.Errorf("expected closing bracket, got \"%v\"", p.current.Literal)
-				}
-				path.WriteString("]")
-				p.advance()
-				if p.current.Type == DOT {
-					continue
-				}
-			} else {
-				break
 			}
-		}
 
-		operator, err := p.parseOperator()
-		if err != nil {
-			return nil, err
-		}
+			operator, err := p.parseOperator()
+			if err != nil {
+				return nil, err
+			}
 
-		value, err := p.parseValue()
-		if err != nil {
-			return nil, err
-		}
+			value, err := p.parseValue()
+			if err != nil {
+				return nil, err
+			}
 
-		pairs = append(pairs, &KeyValuePair{
-			Key:       path.String(),
-			Value:     value,
-			Operator:  operator,
-			IsNegated: isNegated,
-		})
+			filters = append(filters, &Filter{
+				Type: "KeyValuePair",
+				KeyValuePair: &KeyValuePair{
+					Key:       path.String(),
+					Value:     value,
+					Operator:  operator,
+					IsNegated: isNegated,
+				},
+			})
+		}
 
 		if p.current.Type != COMMA && p.current.Type != AND {
 			break
@@ -837,7 +871,7 @@ func (p *Parser) parseKeyValuePairs() ([]*KeyValuePair, error) {
 		p.advance()
 	}
 
-	return pairs, nil
+	return filters, nil
 }
 
 // parseOperator parses comparison operators
@@ -1015,4 +1049,71 @@ func ValidateAnonymousNode(node *NodePattern, relationships []*Relationship) err
 
 	// Node is anonymous and not used in any relationship
 	return fmt.Errorf("standalone anonymous node '()' is not allowed")
+}
+
+// Add after parseMatchClause
+func (p *Parser) trackMatchVariables(nodes []*NodePattern) {
+	for _, node := range nodes {
+		if !node.IsAnonymous && node.ResourceProperties != nil {
+			p.matchVariables[node.ResourceProperties.Name] = node
+		}
+	}
+}
+
+// Add new method to validate submatch patterns
+func (p *Parser) validateSubmatchPattern(nodes []*NodePattern, relationships []*Relationship) error {
+	referenceCount := 0
+	var referenceNode *NodePattern
+
+	// First pass: Find and validate reference nodes
+	for _, node := range nodes {
+		if !node.IsAnonymous {
+			if originalNode, exists := p.matchVariables[node.ResourceProperties.Name]; exists {
+				referenceCount++
+				referenceNode = node
+
+				// Validate reference node doesn't have kind or properties
+				if node.ResourceProperties.Kind != "" {
+					return fmt.Errorf("reference node cannot have a kind")
+				}
+				if node.ResourceProperties.Properties != nil {
+					return fmt.Errorf("reference node cannot have properties")
+				}
+
+				// Copy kind from original node for later use
+				node.ResourceProperties.Kind = originalNode.ResourceProperties.Kind
+			}
+		}
+	}
+
+	// Validate reference count
+	if referenceCount == 0 {
+		return fmt.Errorf("pattern must reference exactly one variable from the MATCH clause")
+	}
+	if referenceCount > 1 {
+		return fmt.Errorf("pattern must reference exactly one variable from the MATCH clause, found %d", referenceCount)
+	}
+
+	// Second pass: Validate other nodes
+	for _, node := range nodes {
+		if node != referenceNode && !node.IsAnonymous {
+			return fmt.Errorf("node '%s' in WHERE pattern must not specify a variable name", node.ResourceProperties.Name)
+		}
+	}
+
+	// TODO: Validate a relationship rule exists between the reference node and the other nodes
+	debugLog("relationhships in validateSubmatchPattern: %v", relationships)
+
+	return nil
+}
+
+// Add new method to extract KeyValuePairs from Filters
+func extractKeyValuePairs(filters []*Filter) []*KeyValuePair {
+	var kvPairs []*KeyValuePair
+	for _, filter := range filters {
+		if filter.Type == "KeyValuePair" {
+			kvPairs = append(kvPairs, filter.KeyValuePair)
+		}
+	}
+	return kvPairs
 }

--- a/pkg/core/parser.go
+++ b/pkg/core/parser.go
@@ -792,12 +792,21 @@ func (p *Parser) parseKeyValuePairs() ([]*Filter, error) {
 				return nil, err
 			}
 
+			var referenceNodeName string
+			for _, node := range nodeRels.Nodes {
+				if !strings.Contains(node.ResourceProperties.Name, "_anon") {
+					referenceNodeName = node.ResourceProperties.Name
+					break
+				}
+			}
+
 			filters = append(filters, &Filter{
 				Type: "SubMatch",
 				SubMatch: &SubMatch{
-					IsNegated:     isNegated,
-					Nodes:         nodeRels.Nodes,
-					Relationships: nodeRels.Relationships,
+					IsNegated:         isNegated,
+					Nodes:             nodeRels.Nodes,
+					Relationships:     nodeRels.Relationships,
+					ReferenceNodeName: referenceNodeName,
 				},
 			})
 		} else {

--- a/pkg/core/parser.go
+++ b/pkg/core/parser.go
@@ -65,7 +65,7 @@ func (p *Parser) Parse() (*Expression, error) {
 	if p.current.Type == WHERE {
 		if matchClause, ok := firstClause.(*MatchClause); ok {
 			p.advance()
-			filters, err := p.parseKeyValuePairs()
+			filters, err := p.parseFilters()
 			if err != nil {
 				return nil, fmt.Errorf("parsing WHERE clause: %w", err)
 			}
@@ -204,7 +204,7 @@ func (p *Parser) parseMatchClause() (*MatchClause, error) {
 	var filters []*Filter
 	if p.current.Type == WHERE {
 		p.advance()
-		filters, err = p.parseKeyValuePairs()
+		filters, err = p.parseFilters()
 		if err != nil {
 			return nil, err
 		}
@@ -541,7 +541,7 @@ func (p *Parser) parseSetClause() (*SetClause, error) {
 	}
 	p.advance()
 
-	filters, err := p.parseKeyValuePairs()
+	filters, err := p.parseFilters()
 	if err != nil {
 		return nil, err
 	}
@@ -772,8 +772,8 @@ func (p *Parser) parseProperties() (*Properties, error) {
 	return &Properties{PropertyList: propertyList}, nil
 }
 
-// parseKeyValuePairs parses a list of key-value pairs with operators
-func (p *Parser) parseKeyValuePairs() ([]*Filter, error) {
+// parseFilters parses a list of either key-value pairs with operators or submatch patterns
+func (p *Parser) parseFilters() ([]*Filter, error) {
 	var filters []*Filter
 
 	for {

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -11,7 +11,7 @@ func init() {
 	LogLevel = "debug"
 }
 
-func TestRecursiveParser(t *testing.T) {
+func TestParser(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -1647,7 +1647,7 @@ func TestParserErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("Testing input: %q", tt.input)
 
-			parser := NewRecursiveParser(tt.input)
+			parser := NewParser(tt.input)
 			_, err := parser.Parse()
 			if err == nil {
 				t.Errorf("ParseQuery() expected error containing %q, got nil", tt.contains)

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -55,11 +55,14 @@ func TestRecursiveParser(t *testing.T) {
 								},
 							},
 						},
-						ExtraFilters: []*KeyValuePair{
+						ExtraFilters: []*Filter{
 							{
-								Key:      "pod.metadata.name",
-								Value:    "nginx",
-								Operator: "EQUALS",
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "pod.metadata.name",
+									Value:    "nginx",
+									Operator: "EQUALS",
+								},
 							},
 						},
 					},
@@ -258,11 +261,14 @@ func TestRecursiveParser(t *testing.T) {
 								},
 							},
 						},
-						ExtraFilters: []*KeyValuePair{
+						ExtraFilters: []*Filter{
 							{
-								Key:      "pod.spec.containers[0].image",
-								Value:    "nginx",
-								Operator: "EQUALS",
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "pod.spec.containers[0].image",
+									Value:    "nginx",
+									Operator: "EQUALS",
+								},
 							},
 						},
 					},
@@ -476,11 +482,14 @@ func TestRecursiveParser(t *testing.T) {
 								},
 							},
 						},
-						ExtraFilters: []*KeyValuePair{
+						ExtraFilters: []*Filter{
 							{
-								Key:      "d.spec.replicas",
-								Value:    1,
-								Operator: "EQUALS",
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "d.spec.replicas",
+									Value:    1,
+									Operator: "EQUALS",
+								},
 							},
 						},
 					},
@@ -618,10 +627,31 @@ func TestRecursiveParser(t *testing.T) {
 						Nodes: []*NodePattern{
 							{ResourceProperties: &ResourceProperties{Name: "p", Kind: "Pod"}},
 						},
-						ExtraFilters: []*KeyValuePair{
-							{Key: "p.status.phase", Value: "Running", Operator: "NOT_EQUALS"},
-							{Key: "p.metadata.name", Value: "^test-.*", Operator: "REGEX_COMPARE"},
-							{Key: "p.spec.containers[0].resources.requests.memory", Value: "Gi", Operator: "CONTAINS"},
+						ExtraFilters: []*Filter{
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "p.status.phase",
+									Value:    "Running",
+									Operator: "NOT_EQUALS",
+								},
+							},
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "p.metadata.name",
+									Value:    "^test-.*",
+									Operator: "REGEX_COMPARE",
+								},
+							},
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "p.spec.containers[0].resources.requests.memory",
+									Value:    "Gi",
+									Operator: "CONTAINS",
+								},
+							},
 						},
 					},
 					&ReturnClause{
@@ -641,10 +671,31 @@ func TestRecursiveParser(t *testing.T) {
 						Nodes: []*NodePattern{
 							{ResourceProperties: &ResourceProperties{Name: "p", Kind: "Pod"}},
 						},
-						ExtraFilters: []*KeyValuePair{
-							{Key: "p.status.phase", Value: "Running", Operator: "NOT_EQUALS"},
-							{Key: "p.metadata.name", Value: "^test-.*", Operator: "REGEX_COMPARE"},
-							{Key: "p.spec.containers[0].resources.requests.memory", Value: "Gi", Operator: "CONTAINS"},
+						ExtraFilters: []*Filter{
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "p.status.phase",
+									Value:    "Running",
+									Operator: "NOT_EQUALS",
+								},
+							},
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "p.metadata.name",
+									Value:    "^test-.*",
+									Operator: "REGEX_COMPARE",
+								},
+							},
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "p.spec.containers[0].resources.requests.memory",
+									Value:    "Gi",
+									Operator: "CONTAINS",
+								},
+							},
 						},
 					},
 					&ReturnClause{
@@ -981,11 +1032,14 @@ func TestRecursiveParser(t *testing.T) {
 								},
 							},
 						},
-						ExtraFilters: []*KeyValuePair{
+						ExtraFilters: []*Filter{
 							{
-								Key:      "pod.spec.containers[*].image",
-								Value:    "nginx",
-								Operator: "EQUALS",
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "pod.spec.containers[*].image",
+									Value:    "nginx",
+									Operator: "EQUALS",
+								},
 							},
 						},
 					},
@@ -1011,11 +1065,14 @@ func TestRecursiveParser(t *testing.T) {
 								},
 							},
 						},
-						ExtraFilters: []*KeyValuePair{
+						ExtraFilters: []*Filter{
 							{
-								Key:      "pod.spec.containers[*].volumeMounts[*].name",
-								Value:    "config",
-								Operator: "EQUALS",
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "pod.spec.containers[*].volumeMounts[*].name",
+									Value:    "config",
+									Operator: "EQUALS",
+								},
 							},
 						},
 					},
@@ -1311,14 +1368,112 @@ func TestRecursiveParser(t *testing.T) {
 						Nodes: []*NodePattern{
 							{ResourceProperties: &ResourceProperties{Name: "p", Kind: "Pod"}},
 						},
-						ExtraFilters: []*KeyValuePair{
-							{Key: "p.status.phase", Value: "Running", Operator: "EQUALS", IsNegated: true},
-							{Key: "p.metadata.name", Value: "test", Operator: "EQUALS", IsNegated: true},
+						ExtraFilters: []*Filter{
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:       "p.status.phase",
+									Value:     "Running",
+									Operator:  "EQUALS",
+									IsNegated: true,
+								},
+							},
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:       "p.metadata.name",
+									Value:     "test",
+									Operator:  "EQUALS",
+									IsNegated: true,
+								},
+							},
 						},
 					},
 					&ReturnClause{
 						Items: []*ReturnItem{
 							{JsonPath: "p.metadata.name"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "match with pattern in WHERE clause",
+			input: `MATCH (s:Service) WHERE NOT (s)->(:Endpoints) RETURN s.metadata.name`,
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{ResourceProperties: &ResourceProperties{Name: "s", Kind: "Service"}},
+						},
+						ExtraFilters: []*Filter{
+							{
+								Type: "SubMatch",
+								SubMatch: &SubMatch{
+									IsNegated: true,
+									Nodes: []*NodePattern{
+										{ResourceProperties: &ResourceProperties{Name: "s", Kind: "Service"}},
+										{ResourceProperties: &ResourceProperties{Name: "_anon1", Kind: "Endpoints"}, IsAnonymous: true},
+									},
+									Relationships: []*Relationship{
+										{
+											Direction: Right,
+											LeftNode:  &NodePattern{ResourceProperties: &ResourceProperties{Name: "s", Kind: "Service"}},
+											RightNode: &NodePattern{ResourceProperties: &ResourceProperties{Name: "_anon1", Kind: "Endpoints"}, IsAnonymous: true},
+										},
+									},
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "s.metadata.name"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "match with pattern and value comparison in WHERE clause",
+			input: `MATCH (pvc:PersistentVolumeClaim) WHERE NOT (pvc)->(:Pod) AND pvc.status.phase = "Bound" RETURN pvc.metadata.name`,
+			want: &Expression{
+				Clauses: []Clause{
+					&MatchClause{
+						Nodes: []*NodePattern{
+							{ResourceProperties: &ResourceProperties{Name: "pvc", Kind: "PersistentVolumeClaim"}},
+						},
+						ExtraFilters: []*Filter{
+							{
+								Type: "SubMatch",
+								SubMatch: &SubMatch{
+									IsNegated: true,
+									Nodes: []*NodePattern{
+										{ResourceProperties: &ResourceProperties{Name: "pvc", Kind: "PersistentVolumeClaim"}},
+										{ResourceProperties: &ResourceProperties{Name: "_anon1", Kind: "Pod"}, IsAnonymous: true},
+									},
+									Relationships: []*Relationship{
+										{
+											Direction: Right,
+											LeftNode:  &NodePattern{ResourceProperties: &ResourceProperties{Name: "pvc", Kind: "PersistentVolumeClaim"}},
+											RightNode: &NodePattern{ResourceProperties: &ResourceProperties{Name: "_anon1", Kind: "Pod"}, IsAnonymous: true},
+										},
+									},
+								},
+							},
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "pvc.status.phase",
+									Value:    "Bound",
+									Operator: "EQUALS",
+								},
+							},
+						},
+					},
+					&ReturnClause{
+						Items: []*ReturnItem{
+							{JsonPath: "pvc.metadata.name"},
 						},
 					},
 				},
@@ -1333,8 +1488,15 @@ func TestRecursiveParser(t *testing.T) {
 						Nodes: []*NodePattern{
 							{ResourceProperties: &ResourceProperties{Name: "d", Kind: "Deployment"}},
 						},
-						ExtraFilters: []*KeyValuePair{
-							{Key: "d.metadata.annotations.meta\\.helm\\.sh/release-name", Value: "my-app", Operator: "EQUALS"},
+						ExtraFilters: []*Filter{
+							{
+								Type: "KeyValuePair",
+								KeyValuePair: &KeyValuePair{
+									Key:      "d.metadata.annotations.meta\\.helm\\.sh/release-name",
+									Value:    "my-app",
+									Operator: "EQUALS",
+								},
+							},
 						},
 					},
 					&ReturnClause{
@@ -1344,6 +1506,36 @@ func TestRecursiveParser(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:    "invalid submatch - no reference to original match variables",
+			input:   `MATCH (s:Service) WHERE NOT (x:Service)->(:Endpoints) RETURN s.metadata.name`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid submatch - reference node includes kind",
+			input:   `MATCH (s:Service) WHERE NOT (s:Service)->(:Endpoints) RETURN s.metadata.name`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid submatch - reference node includes properties",
+			input:   `MATCH (s:Service) WHERE NOT (s {name: "foo"})->(:Endpoints) RETURN s.metadata.name`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid submatch - other node includes variable",
+			input:   `MATCH (s:Service) WHERE NOT (s)->(e:Endpoints) RETURN s.metadata.name`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid submatch - multiple references to match variables",
+			input:   `MATCH (s:Service) WHERE NOT (s)->(:Endpoints)->(s) RETURN s.metadata.name`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid submatch - reference to undefined variable",
+			input:   `MATCH (s:Service) WHERE NOT (x)->(:Endpoints) RETURN s.metadata.name`,
+			wantErr: true,
 		},
 	}
 

--- a/pkg/core/parser_test.go
+++ b/pkg/core/parser_test.go
@@ -1422,6 +1422,7 @@ func TestRecursiveParser(t *testing.T) {
 											RightNode: &NodePattern{ResourceProperties: &ResourceProperties{Name: "_anon1", Kind: "Endpoints"}, IsAnonymous: true},
 										},
 									},
+									ReferenceNodeName: "s",
 								},
 							},
 						},
@@ -1459,6 +1460,7 @@ func TestRecursiveParser(t *testing.T) {
 											RightNode: &NodePattern{ResourceProperties: &ResourceProperties{Name: "_anon1", Kind: "Pod"}, IsAnonymous: true},
 										},
 									},
+									ReferenceNodeName: "pvc",
 								},
 							},
 							{

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -46,9 +46,10 @@ type Filter struct {
 
 // SubMatch represents a pattern match within a WHERE clause
 type SubMatch struct {
-	IsNegated     bool
-	Nodes         []*NodePattern
-	Relationships []*Relationship
+	IsNegated         bool
+	Nodes             []*NodePattern
+	Relationships     []*Relationship
+	ReferenceNodeName string
 }
 
 // CreateClause represents a CREATE clause

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -34,7 +34,21 @@ type Clause interface {
 type MatchClause struct {
 	Nodes         []*NodePattern
 	Relationships []*Relationship
-	ExtraFilters  []*KeyValuePair
+	ExtraFilters  []*Filter
+}
+
+// Filter represents a filter condition in a WHERE clause
+type Filter struct {
+	Type         string        // "KeyValuePair" or "SubMatch"
+	KeyValuePair *KeyValuePair // Used when Type is "KeyValuePair"
+	SubMatch     *SubMatch     // Used when Type is "SubMatch"
+}
+
+// SubMatch represents a pattern match within a WHERE clause
+type SubMatch struct {
+	IsNegated     bool
+	Nodes         []*NodePattern
+	Relationships []*Relationship
 }
 
 // CreateClause represents a CREATE clause


### PR DESCRIPTION
This PR adds the ability to use patterns inside WHERE clauses which is especially useful for discovering orphaned resources.

Examples:
```graphql
# Find unused configmaps
MATCH (cm:ConfigMap)
WHERE NOT (cm)->(:Pod)
RETURN cm
```

```graphql
# Find services without endpoints
MATCH (s:Service)
WHERE NOT (s)->(:Endpoints)
RETURN s.metadata.name;
```

```graphql
# Find orphaned PVCs
MATCH (pvc:PersistentVolumeClaim)
WHERE NOT (pvc)->(:Pod)
AND pvc.status.phase = "Bound"
RETURN pvc.metadata.name;
```

Closes #198 