### PR TITLE
fix(web): prevent panic when autocompleting in beginning of line

### DIFF
--- a/cmd/cyphernetes/shell-autocomplete.go
+++ b/cmd/cyphernetes/shell-autocomplete.go
@@ -21,10 +21,10 @@ func (c *CyphernetesCompleter) Do(line []rune, pos int) ([][]rune, int) {
 	}
 
 	words := strings.Fields(lineStr)
-	lastWord := words[len(words)-1]
-	prefix := strings.ToLower(lastWord)
-
+	var lastWord string
 	if len(words) > 0 {
+		lastWord = words[len(words)-1]
+		prefix := strings.ToLower(lastWord)
 		resourceKindIdentifierRegex := regexp.MustCompile(`(\(\w+:\w+$|\)->\(\w+:\w+$)`)
 		if resourceKindIdentifierRegex.MatchString(lastWord) {
 			var identifier string


### PR DESCRIPTION
Fix a panic in web when a query is already inputted and the cursor is moved back to beginning of line