### PR TITLE
Use Cypher syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kubectl get pods --all-namespaces --field-selector 'status.phase!=Running' \
 ```
 
 Into this: 🤩 
-```graphql
+```cypher
 // Do the same thing!
 
 MATCH (p:Pod)
@@ -42,7 +42,7 @@ There are multiple ways to run Cyphernetes queries:
 5. Using the Cyphernetes API in your own Go programs.
 
 ### Examples
-```graphql
+```cypher
 // Get the desired and running replicas for all deployments
 MATCH (d:Deployment)
 RETURN d.spec.replicas AS desiredReplicas, 
@@ -65,7 +65,7 @@ Cyphernetes' superpower is understanding the relationships between Kubernetes re
 This feature is expressed using the arrows (`->`) you see in the example queries.
 Relationships let us express connected operations in a natural way, and without having to worry about the underlying Kubernetes API:
 
-```graphql
+```cypher
 // This is similar to `kubectl expose`
 MATCH (d:Deployment {name: "nginx"})
 CREATE (d)->(s:Service);

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kubectl get pods --all-namespaces --field-selector 'status.phase!=Running' \
 ```
 
 Into this: 🤩 
-```cypher
+```graphql
 // Do the same thing!
 
 MATCH (p:Pod)
@@ -42,7 +42,7 @@ There are multiple ways to run Cyphernetes queries:
 5. Using the Cyphernetes API in your own Go programs.
 
 ### Examples
-```cypher
+```graphql
 // Get the desired and running replicas for all deployments
 MATCH (d:Deployment)
 RETURN d.spec.replicas AS desiredReplicas, 
@@ -65,7 +65,7 @@ Cyphernetes' superpower is understanding the relationships between Kubernetes re
 This feature is expressed using the arrows (`->`) you see in the example queries.
 Relationships let us express connected operations in a natural way, and without having to worry about the underlying Kubernetes API:
 
-```cypher
+```graphql
 // This is similar to `kubectl expose`
 MATCH (d:Deployment {name: "nginx"})
 CREATE (d)->(s:Service);

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -65,7 +65,7 @@ You can list available macros by running `\lm` in the shell.
 
 You can use a macro by running `:<macro-name>` in the shell:
 
-```graphql
+```cypher
 > :getpo
 
 {
@@ -167,7 +167,7 @@ The relationships.yaml file supports the following fields:
 
 Custom relationships are loaded on startup and can be used just like built-in relationships in queries:
 
-```graphql
+```cypher
 MATCH (d:Deployment)->(p:Pod)
 RETURN d.metadata.name, p.metadata.name
 ```

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -12,7 +12,7 @@ This guide provides practical examples of using Cyphernetes in various scenarios
 
 Basic node patterns with and without variables:
 
-```graphql
+```cypher
 // Basic node pattern
 MATCH (p:Pod)
 RETURN p;
@@ -34,7 +34,7 @@ RETURN p, x.kind;
 
 Different ways to express relationships between resources:
 
-```graphql
+```cypher
 // Right direction relationship
 MATCH (p:Pod)->(s:Service)
 RETURN p.metadata.name, s.metadata.name;
@@ -58,7 +58,7 @@ RETURN d.metadata.name, p.metadata.name;
 
 Find and manage pods in your cluster:
 
-```graphql
+```cypher
 // List all pods that aren't running
 MATCH (p:Pod)
 WHERE p.status.phase != "Running"
@@ -89,7 +89,7 @@ DELETE p;
 
 Work with deployments and their related resources:
 
-```graphql
+```cypher
 // Scale deployments in a namespace
 MATCH (d:Deployment {namespace: "production"})
 SET d.spec.replicas = 3;
@@ -115,7 +115,7 @@ RETURN d.metadata.name;
 
 Analyze services and their endpoints:
 
-```graphql
+```cypher
 // Find services without endpoints
 MATCH (s:Service)
 WHERE NOT (s)->(:core.Endpoints)
@@ -138,7 +138,7 @@ RETURN s.metadata.name, s.spec.clusterIP;
 
 Find relationships between different resource types:
 
-```graphql
+```cypher
 // Find all resources related to a deployment
 MATCH (d:Deployment {app: "my-app"})->(x)
 RETURN d, x.kind, x.metadata.name;


### PR DESCRIPTION
Due to historical reasons, we were using GraphQL syntax highlighting in documentation.
Now that we're very much aligned with vanilla Cypher, let's use proper Cypher syntax highlighting across the board.