### PR TITLE
feat: add relationship when parent prop is a GVR and child prop 'name'

### DIFF
--- a/pkg/core/relationship.go
+++ b/pkg/core/relationship.go
@@ -336,7 +336,6 @@ func InitializeRelationships(resourceSpecs map[string][]string, provider provide
 					continue
 				}
 
-				// Important: Keep the array notation in the field path
 				fullFieldPath := fieldPath
 				if relSpecType == "Ref" || relSpecType == "KeyRef" {
 					fullFieldPath = fieldPath + ".name"
@@ -581,7 +580,6 @@ func GetRelationships() map[string][]string {
 	return relationships
 }
 
-// Modified to handle rules with similar relationship types
 func findRelationshipRulesBetweenKinds(kindA, kindB string) []RelationshipRule {
 	var matchingRules []RelationshipRule
 

--- a/pkg/core/relationship.go
+++ b/pkg/core/relationship.go
@@ -183,10 +183,10 @@ func InitializeRelationships(resourceSpecs map[string][]string, provider provide
 				if parentGVR != (schema.GroupVersionResource{}) {
 					relatedKindSingularFromParentGVR := parentGVR.Resource
 
-					// Proceed with creating/updating the dynamic rule
-					relType := RelationshipType(fmt.Sprintf("%s_REFERENCES_%s_BY_PARENT_FIELD",
-						strings.ToUpper(gvrA.Resource),
-						strings.ToUpper(relatedKindSingularFromParentGVR)))
+					// Use the standard INSPEC relationship format instead of creating a special BY_PARENT_FIELD rule
+					relType := RelationshipType(fmt.Sprintf("%s_INSPEC_%s",
+						strings.ToUpper(relatedKindSingularFromParentGVR),
+						strings.ToUpper(kindANameSingular)))
 
 					ruleKindA := strings.ToLower(gvrA.Resource)
 					ruleKindB := strings.ToLower(relatedKindSingularFromParentGVR)
@@ -217,7 +217,7 @@ func InitializeRelationships(resourceSpecs map[string][]string, provider provide
 					fieldA := "$." + fieldPath  // Path to the "name" field itself
 					fieldB := "$.metadata.name" // Standard target
 
-					debugLog("Creating relationship rule (parent GVR): %s -> %s with fields: %s -> %s for relType: %s", ruleKindA, ruleKindB, fieldA, fieldB, relType)
+					debugLog("Creating relationship rule (parent GVR) for: %s -> %s with fields: %s -> %s for relType: %s", ruleKindA, ruleKindB, fieldA, fieldB, relType)
 					criterion := MatchCriterion{
 						FieldA:         fieldA,
 						FieldB:         fieldB,
@@ -259,7 +259,7 @@ func InitializeRelationships(resourceSpecs map[string][]string, provider provide
 						relationshipRules = append(relationshipRules, rule)
 						relationshipCount++
 					}
-					processedThisField = true // Mark as processed by parent GVR logic (or intentionally skipped section)
+					processedThisField = true // Mark as processed by parent GVR logic
 				}
 			}
 


### PR DESCRIPTION
this makes sure we create a relationships when a field's name is "name" and it's parent resolves to a valid GVR.
example:
```
kind: pod
spec:
  configmap:
    name: foo
```

will create a relationship rule between pods a configmaps