### PR TITLE
Fix crd without list verb

### DIFF
--- a/pkg/provider/apiserver/provider.go
+++ b/pkg/provider/apiserver/provider.go
@@ -1215,7 +1215,7 @@ func (p *APIServerProvider) initGVRCache() error {
 
 			// Exclude internal resources like bindings, tokenreviews etc. which has only `create` verb
 			// and does not include `get` or `list` as they cannot be queried.
-			if len(r.Verbs) > 1 && strings.Contains(fmt.Sprintf("%v", r.Verbs), "list") {
+			if strings.Contains(fmt.Sprintf("%v", r.Verbs), "list") {
 				p.knownResourceKinds = append(p.knownResourceKinds, r.Name)
 			}
 

--- a/pkg/provider/apiserver/provider.go
+++ b/pkg/provider/apiserver/provider.go
@@ -1215,7 +1215,7 @@ func (p *APIServerProvider) initGVRCache() error {
 
 			// Exclude internal resources like bindings, tokenreviews etc. which has only `create` verb
 			// and does not include `get` or `list` as they cannot be queried.
-			if len(r.Verbs) > 1 {
+			if len(r.Verbs) > 1 && strings.Contains(fmt.Sprintf("%v", r.Verbs), "list") {
 				p.knownResourceKinds = append(p.knownResourceKinds, r.Name)
 			}
 


### PR DESCRIPTION
Fix for including only CRDs with `list` verb available to be added as known resource kinds. 

There are CRDs which have `create`, `delete` with no list verbs, where this logic actually breaks. Rather than check if more than one verb is present, 
```
if len(r.Verbs) > 1 {
```
a better way to check is if actual `list` verb is available in the list of verb strings.
```
if strings.Contains(fmt.Sprintf("%v", r.Verbs), "list") {
```