### PR TITLE
Fix for setting namespace after execute query

### DIFF
--- a/pkg/core/execute.go
+++ b/pkg/core/execute.go
@@ -20,7 +20,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 	if AllNamespaces {
 		Namespace = ""
 		AllNamespaces = false // to reset value
-	} else if namespace != "" {
+	} else {
 		Namespace = namespace
 	}
 

--- a/pkg/core/relationship.go
+++ b/pkg/core/relationship.go
@@ -89,6 +89,11 @@ func containsResource(resources []map[string]interface{}, resource map[string]in
 		return false
 	}
 
+	ns1, ok1 := metadata1["namespace"].(string)
+	if !ok1 {
+		ns1 = ""
+	}
+
 	for _, res := range resources {
 		metadata2, ok2 := res["metadata"].(map[string]interface{})
 		if !ok2 {
@@ -98,7 +103,11 @@ func containsResource(resources []map[string]interface{}, resource map[string]in
 		if !ok2 {
 			continue
 		}
-		if name1 == name2 {
+		ns2, _ := metadata2["namespace"].(string)
+		if !ok2 {
+			ns2 = ""
+		}
+		if name1 == name2 && ns1 == ns2 {
 			return true
 		}
 	}


### PR DESCRIPTION
This PR contains fixes for 2 issues.
1. Package scoped variable `Namespace` contains stale value, when a query is first executed with a specific namespace followed by a query execution with empty namespace (cluster scoped). Changes done to `pkg/core/execute.go`
eg:
execute the query in the following order
```
queryExecutor := GetQueryExecutorInstance(provider)
queryExecutor.ExecuteSingleQuery(ast, "guestbook")
queryExecutor.ExecuteSingleQuery(ast, "")
```
the second query is expected to be run in cluster scope with namespace set to `""`, however, the namespace override is conditional, and the package level variable `Namespace` is set only when input namespace is not empty.
2. When a resource is added to the results, we check if the resource is already contained in the resource list using the `containsResource` method in `pkg/core/relationship.go`. This check only considers the name of the resource, however it is possible to have the same resource name in multiple namespaces. Let's say I am deploying an application in 3 environments prod, dev, stage each assigned to a namespace. If a cluster scoped query is executed, it returns only one `Deployment` instead of 3 deployment objects. The fix is to include the namespace of the resource too when checking if a resource is already processed.