### PR TITLE
Harden core query execution

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,6 +36,8 @@ jobs:
       run: make operator-manifests
     - name: Run tests
       run: make test
+    - name: Enforce core coverage
+      run: make core-coverage
     - name: Run web tests
       run: make web-test
     - name: Apply operator test CRDs

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ KUBECTL_PLUGIN_NAME=kubectl-cypher
 TARGET_KERNELS=darwin linux windows
 TARGET_ARCHS=amd64 arm64
 VERSION ?= dev
+CORE_COVERAGE_MIN ?= 80.0
 
 # Define the default make target
 all: operator-manifests bt
@@ -55,6 +56,21 @@ build-kubectl-plugin-all-platforms:
 test:
 	@echo "🧪 Running tests..."
 	go test ./...
+
+core-coverage:
+	@echo "🧪 Checking pkg/core coverage..."
+	@set -e; \
+	tmp=$$(mktemp); \
+	trap 'rm -f "$$tmp"' EXIT; \
+	go test ./pkg/core -covermode=atomic -coverprofile=$$tmp; \
+	total=$$(go tool cover -func=$$tmp | awk '/^total:/ {gsub("%", "", $$3); print $$3}'); \
+	awk -v total="$$total" -v min="$(CORE_COVERAGE_MIN)" 'BEGIN { \
+		if (total + 0 < min + 0) { \
+			printf("pkg/core coverage %.1f%% is below %.1f%%\n", total, min); \
+			exit 1; \
+		} \
+		printf("pkg/core coverage %.1f%% meets %.1f%% floor\n", total, min); \
+	}'
 
 .PHONY: test-e2e
 test-e2e:
@@ -110,8 +126,8 @@ web-run: build
 	./dist/cyphernetes web
 
 # Define a phony target for the clean command to ensure it always runs
-.PHONY: clean build-kubectl-plugin build-kubectl-plugin-all-platforms
-.SILENT: build build-kubectl-plugin test gen-parser clean coverage operator operator-test operator-manifests operator-docker-build operator-docker-push web-build web-test
+.PHONY: clean build-kubectl-plugin build-kubectl-plugin-all-platforms core-coverage
+.SILENT: build build-kubectl-plugin test core-coverage gen-parser clean coverage operator operator-test operator-manifests operator-docker-build operator-docker-push web-build web-test
 
 # Add a help command to list available targets
 help:
@@ -122,4 +138,5 @@ help:
 	@echo "  build-all-platforms                - Build main binary for all platforms."
 	@echo "  build-kubectl-plugin-all-platforms - Build kubectl plugin for all platforms."
 	@echo "  test                               - Run tests."
+	@echo "  core-coverage                      - Enforce pkg/core unit coverage floor."
 	@echo "  clean                              - Remove binaries and clean up."

--- a/operator/README.md
+++ b/operator/README.md
@@ -1,114 +1,92 @@
-# operator
-// TODO(user): Add simple overview of use/purpose
+# Cyphernetes Operator
 
-## Description
-// TODO(user): An in-depth paragraph about your project and overview of use
+Cyphernetes is available as a Kubernetes Operator that can be used to define child operators on-the-fly.
 
-## Getting Started
+## Usage
 
-### Prerequisites
-- go version v1.22.0+
-- docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+The cyphernetes-operator watches for CustomResourceDefinitions (CRDs) of type `DynamicOperator` and sets up watches on the specified Kubernetes resources.
+When a change is detected, the operator executes the Cypher queries and updates the resources accordingly.
 
-### To Deploy on the cluster
-**Build and push your image to the location specified by `IMG`:**
+Here is a simple example of a DynamicOperator that sets the ingress class name to "inactive" when the deployment has 0 replicas and to "active" when the deployment has more than 0 replicas:
 
-```sh
-make docker-build docker-push IMG=<some-registry>/operator:tag
+```yaml
+apiVersion: cyphernetes-operator.cyphernet.es/v1
+kind: DynamicOperator
+metadata:
+  name: ingress-activator-operator
+spec:
+  resourceKind: deployments
+  namespace: default
+  onUpdate: |
+    MATCH (d:Deployment {name: "{{$.metadata.name}}"})->(s:Service)->(i:Ingress)
+    WHERE d.spec.replicas = 0
+    SET i.spec.ingressClassName = "inactive";
+    MATCH (d:Deployment {name: "{{$.metadata.name}}"})->(s:Service)->(i:Ingress)
+    WHERE d.spec.replicas > 0
+    SET i.spec.ingressClassName = "active";
 ```
 
-**NOTE:** This image ought to be published in the personal registry you specified.
-And it is required to have access to pull the image from the working environment.
-Make sure you have the proper permission to the registry if the above commands don’t work.
+In addition to the `onUpdate` field, the operator also supports the `onCreate` and `onDelete` fields.
 
-**Install the CRDs into the cluster:**
+## Installation
 
-```sh
-make install
+The operator can be installed either using Helm, or using the Cyphernetes CLI.
+
+### Helm
+
+To install the operator using Helm, run the following command:
+
+```bash
+helm pull oci://ghcr.io/avitaltamir/cyphernetes/cyphernetes-operator
+tar -xvf cyphernetes-operator-*.tgz
+cd cyphernetes-operator
+helm upgrade --install cyphernetes-operator . --namespace cyphernetes-operator --create-namespace
 ```
 
-**Deploy the Manager to the cluster with the image specified by `IMG`:**
+Make sure to edit the values.yaml file and configure the operator's RBAC rules.
+By default, the operator will have no permissions and will not be able to watch any resources.
 
-```sh
-make deploy IMG=<some-registry>/operator:tag
+### Cyphernetes CLI
+
+Alternatively, you can install the operator using the Cyphernetes CLI - this is meant for development and testing purposes:
+
+```bash
+cyphernetes operator deploy
 ```
 
-> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin.
+To remove the operator:
 
-**Create instances of your solution**
-You can apply the samples (examples) from the config/sample:
-
-```sh
-kubectl apply -k config/samples/
+```bash
+cyphernetes operator remove
 ```
 
->**NOTE**: Ensure that the samples has default values to test it out.
+## Using the operator
 
-### To Uninstall
-**Delete the instances (CRs) from the cluster:**
+To start watching resources, you need to provision your first `DynamicOperator` resource.
 
-```sh
-kubectl delete -k config/samples/
+```yaml
+apiVersion: cyphernetes-operator.cyphernet.es/v1
+kind: DynamicOperator
+metadata:
+  name: ingress-activator-operator
+  namespace: default
+spec:
+  resourceKind: deployments
+  namespace: default
+  onUpdate: |
+    MATCH (d:Deployment {name: "{{$.metadata.name}}"})->(s:Service)->(i:Ingress)
+    WHERE d.spec.replicas = 0
+    SET i.spec.ingressClassName = "inactive";
+    MATCH (d:Deployment {name: "{{$.metadata.name}}"})->(s:Service)->(i:Ingress)
+    WHERE d.spec.replicas > 0
+    SET i.spec.ingressClassName = "active";
 ```
 
-**Delete the APIs(CRDs) from the cluster:**
+The operator will now watch the `deployments` resource in the `default` namespace and update the ingress class name accordingly.
+In addition to the `onUpdate` field, the operator also supports the `onCreate` and `onDelete` fields.
 
-```sh
-make uninstall
+You can easily template `DynamicOperator` resources using the Cyphernetes CLI:
+
+```bash
+cyphernetes operator create my-operator --on-create "MATCH (n) RETURN n" | kubectl apply -f -
 ```
-
-**UnDeploy the controller from the cluster:**
-
-```sh
-make undeploy
-```
-
-## Project Distribution
-
-Following are the steps to build the installer and distribute this project to users.
-
-1. Build the installer for the image built and published in the registry:
-
-```sh
-make build-installer IMG=<some-registry>/operator:tag
-```
-
-NOTE: The makefile target mentioned above generates an 'install.yaml'
-file in the dist directory. This file contains all the resources built
-with Kustomize, which are necessary to install this project without
-its dependencies.
-
-2. Using the installer
-
-Users can just run kubectl apply -f <URL for YAML BUNDLE> to install the project, i.e.:
-
-```sh
-kubectl apply -f https://raw.githubusercontent.com/<org>/operator/<tag or branch>/dist/install.yaml
-```
-
-## Contributing
-// TODO(user): Add detailed information on how you would like others to contribute to this project
-
-**NOTE:** Run `make help` for more information on all potential `make` targets
-
-More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
-
-## License
-
-Copyright 2024.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-

--- a/pkg/core/cache.go
+++ b/pkg/core/cache.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/avitaltamir/cyphernetes/pkg/provider"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,30 +36,31 @@ func InitResourceSpecs(p provider.Provider) error {
 	return nil
 }
 
-func (q *QueryExecutor) resourcePropertyName(n *NodePattern) (string, error) {
-	var ns string
-
-	gvr, err := q.provider.FindGVR(n.ResourceProperties.Kind)
+func (q *QueryExecutor) resourceFetchKey(n *NodePattern, namespace, fieldSelector, labelSelector string, extraFilters []*Filter) (string, error) {
+	gvr, err := tryResolveGVR(q.provider, n.ResourceProperties.Kind)
 	if err != nil {
 		return "", err
 	}
 
-	if n.ResourceProperties.Properties == nil {
-		return fmt.Sprintf("%s_%s", Namespace, gvr.Resource), nil
-	}
-
-	for _, prop := range n.ResourceProperties.Properties.PropertyList {
-		if prop.Key == "namespace" || prop.Key == "metadata.namespace" {
-			ns = prop.Value.(string)
-			break
+	properties := []string{}
+	if n.ResourceProperties.Properties != nil {
+		for _, prop := range n.ResourceProperties.Properties.PropertyList {
+			properties = append(properties, fmt.Sprintf("%s=%#v", prop.Key, prop.Value))
 		}
 	}
+	sort.Strings(properties)
 
-	if ns == "" {
-		ns = Namespace
-	}
-
-	return fmt.Sprintf("%s_%s", ns, gvr.Resource), nil
+	return strings.Join([]string{
+		namespace,
+		gvr.Group,
+		gvr.Version,
+		gvr.Resource,
+		n.ResourceProperties.Name,
+		fieldSelector,
+		labelSelector,
+		strings.Join(properties, ","),
+		filterSignature(extraFilters),
+	}, "\x00"), nil
 }
 
 func (q *QueryExecutor) GetOpenAPIResourceSpecs() (map[string][]string, error) {

--- a/pkg/core/engine.go
+++ b/pkg/core/engine.go
@@ -33,36 +33,27 @@ type QueryResult struct {
 	Graph Graph
 }
 
-var resultCache = make(map[string]interface{})
-var resultMap = make(map[string]interface{})
-
 type QueryExecutor struct {
-	provider       provider.Provider
-	requestChannel chan *apiRequest
-	semaphore      chan struct{}
-	matchNodes     []*NodePattern
-	currentAst     *Expression
+	provider provider.Provider
 }
 
 var (
-	executorInstance *QueryExecutor
-	contextExecutors map[string]*QueryExecutor
-	once             sync.Once
-	GvrCache         map[string]schema.GroupVersionResource
-	ResourceSpecs    map[string][]string
-	executorsLock    sync.RWMutex
-	resultMapMutex   sync.RWMutex
-	Namespace        string
-	LogLevel         string
-	OutputFormat     string
-	AllNamespaces    bool
-	CleanOutput      bool
-	NoColor          bool
+	executorInstance  *QueryExecutor
+	contextExecutors  map[string]*QueryExecutor
+	once              sync.Once
+	GvrCache          map[string]schema.GroupVersionResource
+	ResourceSpecs     map[string][]string
+	executorsLock     sync.RWMutex
+	Namespace         string
+	LogLevel          string
+	OutputFormat      string
+	AllNamespaces     bool
+	CleanOutput       bool
+	NoColor           bool
+	executionConfigMu sync.Mutex
 	// For testing
 	mockFindPotentialKinds func([]*Relationship) []string
 )
-
-type apiRequest struct{}
 
 func NewQueryExecutor(p provider.Provider) (*QueryExecutor, error) {
 	if p == nil {
@@ -70,9 +61,7 @@ func NewQueryExecutor(p provider.Provider) (*QueryExecutor, error) {
 	}
 
 	return &QueryExecutor{
-		provider:       p,
-		requestChannel: make(chan *apiRequest),
-		semaphore:      make(chan struct{}, 1),
+		provider: p,
 	}, nil
 }
 
@@ -84,9 +73,6 @@ func (q *QueryExecutor) Execute(ast *Expression, namespace string) (QueryResult,
 		return ExecuteMultiContextQuery(ast, namespace)
 	}
 
-	// Store the current AST
-	q.currentAst = ast
-
 	// First, check for kindless nodes and rewrite the query if needed
 	rewrittenAst, err := q.rewriteQueryForKindlessNodes(ast)
 	if err != nil {
@@ -94,7 +80,6 @@ func (q *QueryExecutor) Execute(ast *Expression, namespace string) (QueryResult,
 	}
 	if rewrittenAst != nil {
 		ast = rewrittenAst
-		q.currentAst = rewrittenAst
 	}
 
 	result, err := q.ExecuteSingleQuery(ast, namespace)

--- a/pkg/core/execute.go
+++ b/pkg/core/execute.go
@@ -11,25 +11,21 @@ import (
 )
 
 func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (QueryResult, error) {
+	return q.executeSingleQuery(ast, namespace, newExecutionState())
+}
+
+func (q *QueryExecutor) executeSingleQuery(ast *Expression, namespace string, state *executionState) (QueryResult, error) {
 	if ast == nil {
 		return QueryResult{}, fmt.Errorf("empty query: ast cannot be nil")
 	}
-	// Reset match nodes at the start of each query
-	q.matchNodes = nil
 
-	// Store the original namespace to restore it later
-	originalNamespace := Namespace
-	defer func() {
-		Namespace = originalNamespace
-	}()
-
+	state.namespace = namespace
+	executionConfigMu.Lock()
 	if AllNamespaces {
-		Namespace = ""
+		state.namespace = ""
 		AllNamespaces = false // to reset value
-	} else {
-		// Always set the namespace for this query execution, even if empty
-		Namespace = namespace
 	}
+	executionConfigMu.Unlock()
 
 	results := &QueryResult{
 		Data: make(map[string]interface{}),
@@ -44,7 +40,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 		switch c := clause.(type) {
 		case *MatchClause:
 			// Store the nodes from the match clause
-			q.matchNodes = c.Nodes
+			state.matchNodes = c.Nodes
 
 			var filteringOccurred bool
 			filteredResults := make(map[string][]map[string]interface{})
@@ -52,7 +48,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 			for i := 0; i < len(c.Relationships)*2; i++ {
 				filteringOccurred = false
 				for _, rel := range c.Relationships {
-					filtered, err := q.processRelationship(rel, c, results, filteredResults)
+					filtered, err := q.processRelationship(rel, c, results, filteredResults, state)
 					if err != nil {
 						return *results, err
 					}
@@ -63,18 +59,18 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				}
 				// Update resultMap with filtered results for the next pass
 				for k, v := range filteredResults {
-					resultMap[k] = v
+					state.setResources(k, v)
 				}
 			}
 
 			// Process nodes
-			err := q.processNodes(c, results)
+			err := q.processNodes(c, results, state)
 			if err != nil {
 				return *results, err
 			}
 
 		case *SetClause:
-			err := q.handleSetClause(c)
+			err := q.handleSetClause(c, state)
 			if err != nil {
 				return *results, fmt.Errorf("error handling SET clause: %w", err)
 			}
@@ -82,7 +78,8 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 		case *DeleteClause:
 			// Execute a Kubernetes delete operation based on the DeleteClause.
 			for _, nodeId := range c.NodeIds {
-				if resultMap[nodeId] == nil {
+				resources, ok := state.getResources(nodeId)
+				if !ok {
 					// Skip error for expanded node identifiers
 					if strings.Contains(nodeId, "__exp__") {
 						debugLog("skipping error trying to delete expanded node identifier %s", nodeId)
@@ -91,15 +88,20 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 					return *results, fmt.Errorf("node identifier %s not found in result map", nodeId)
 				}
 
-				resources := resultMap[nodeId].([]map[string]interface{})
 				for _, resource := range resources {
-					metadata := resource["metadata"].(map[string]interface{})
-					name := metadata["name"].(string)
+					metadata, err := getResourceMetadata(resource)
+					if err != nil {
+						return *results, fmt.Errorf("error reading resource metadata for node %s: %w", nodeId, err)
+					}
+					name, err := getResourceName(metadata)
+					if err != nil {
+						return *results, fmt.Errorf("error reading resource name for node %s: %w", nodeId, err)
+					}
 					namespace := getNamespaceName(metadata)
 
 					// Find the matching node from the stored match nodes
 					var nodeKind string
-					for _, node := range q.matchNodes {
+					for _, node := range state.matchNodes {
 						if node.ResourceProperties.Name == nodeId {
 							nodeKind = node.ResourceProperties.Kind
 							break
@@ -109,13 +111,17 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 						return *results, fmt.Errorf("could not find kind for node %s in MATCH clause", nodeId)
 					}
 
-					err := q.provider.DeleteK8sResources(nodeKind, name, namespace)
+					providerKind, err := q.providerKind(nodeKind)
+					if err != nil {
+						return *results, fmt.Errorf("error resolving resource kind %s: %v", nodeKind, err)
+					}
+					err = q.provider.DeleteK8sResources(providerKind, name, namespace)
 					if err != nil {
 						return *results, fmt.Errorf("error deleting resource %s/%s: %v", nodeKind, name, err)
 					}
 				}
 
-				delete(resultMap, nodeId)
+				state.deleteResources(nodeId)
 			}
 
 		case *CreateClause:
@@ -130,29 +136,41 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				// Determine which (if any) of the nodes in the relationship have already been fetched in a match clause, and which are new creations
 				var node *NodePattern
 				var foreignNode *NodePattern
+				leftResources, leftExists := state.getResources(rel.LeftNode.ResourceProperties.Name)
+				rightResources, rightExists := state.getResources(rel.RightNode.ResourceProperties.Name)
 
 				// If both nodes exist in the match clause, error out
-				if resultMap[rel.LeftNode.ResourceProperties.Name] != nil && resultMap[rel.RightNode.ResourceProperties.Name] != nil {
+				if leftExists && rightExists {
 					return *results, fmt.Errorf("both nodes '%v', '%v' of relationship in create clause already exist", rel.LeftNode.ResourceProperties.Name, rel.RightNode.ResourceProperties.Name)
 				}
 
 				// TODO: create both nodes and determine the spec from the relationship instead of this:
 				// If neither node exists in the match clause, error out
-				if resultMap[rel.LeftNode.ResourceProperties.Name] == nil && resultMap[rel.RightNode.ResourceProperties.Name] == nil {
+				if !leftExists && !rightExists {
 					return *results, fmt.Errorf("not yet supported: neither node '%s', '%s' of relationship in create clause already exist", rel.LeftNode.ResourceProperties.Name, rel.RightNode.ResourceProperties.Name)
 				}
 
 				// find out whice node exists in the match clause, then use it to construct the spec according to the relationship
-				if resultMap[rel.LeftNode.ResourceProperties.Name] == nil {
+				var foreignResources []map[string]interface{}
+				if !leftExists {
 					node = rel.LeftNode
 					foreignNode = rel.RightNode
+					foreignResources = rightResources
 				} else {
 					node = rel.RightNode
 					foreignNode = rel.LeftNode
+					foreignResources = leftResources
 				}
 
 				// The foreign node is currently only a name reference, we'll need to find the matching node in the result map
-				foreignNode.ResourceProperties.Kind = resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{})[0]["kind"].(string)
+				if len(foreignResources) == 0 {
+					return *results, fmt.Errorf("no resources found for foreign node %s", foreignNode.ResourceProperties.Name)
+				}
+				foreignKind, err := getResourceKind(foreignResources[0])
+				if err != nil {
+					return *results, fmt.Errorf("error reading kind for foreign node %s: %w", foreignNode.ResourceProperties.Name, err)
+				}
+				foreignNode.ResourceProperties.Kind = foreignKind
 
 				var relType RelationshipType
 				targetGVR, err := q.findGVR(node.ResourceProperties.Kind)
@@ -161,7 +179,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				}
 				// Find the matching node from stored match nodes to get the kind
 				var foreignNodeKind string
-				for _, matchNode := range q.matchNodes {
+				for _, matchNode := range state.matchNodes {
 					if matchNode.ResourceProperties.Name == foreignNode.ResourceProperties.Name {
 						foreignNodeKind = matchNode.ResourceProperties.Kind
 						break
@@ -234,9 +252,9 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				}
 
 				// loop over the resources array in the resultMap for the foreign node and create the resource
-				for idx, foreignResource := range resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{}) {
+				for idx, foreignResource := range foreignResources {
 					var name string
-					foreignSpec := resultMap[foreignNode.ResourceProperties.Name].([]map[string]interface{})[idx]
+					foreignSpec := foreignResources[idx]
 
 					fields := append([]string{criteriaField}, defaultPropFields...)
 					foreignFields := append([]string{foreignCriteriaField}, foreignDefaultPropFields...)
@@ -313,11 +331,23 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 						}
 					}
 
-					name = getTargetK8sResourceName(resourceTemplate, node.ResourceProperties.Name, foreignResource["metadata"].(map[string]interface{})["name"].(string))
+					foreignMetadata, err := getResourceMetadata(foreignResource)
+					if err != nil {
+						return *results, fmt.Errorf("error reading foreign resource metadata: %w", err)
+					}
+					foreignName, err := getResourceName(foreignMetadata)
+					if err != nil {
+						return *results, fmt.Errorf("error reading foreign resource name: %w", err)
+					}
+					name = getTargetK8sResourceName(resourceTemplate, node.ResourceProperties.Name, foreignName)
+					providerKind, err := q.providerKind(node.ResourceProperties.Kind)
+					if err != nil {
+						return *results, fmt.Errorf("error resolving resource kind %s: %v", node.ResourceProperties.Kind, err)
+					}
 					err = q.provider.CreateK8sResource(
-						node.ResourceProperties.Kind,
+						providerKind,
 						name,
-						Namespace,
+						state.namespace,
 						resourceTemplate,
 					)
 					if err != nil {
@@ -338,7 +368,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 				if !ignoreNode {
 					// check if the node has already been fetched, if so, error out
-					if resultMap[node.ResourceProperties.Name] != nil {
+					if _, exists := state.getResources(node.ResourceProperties.Name); exists {
 						return *results, fmt.Errorf("can't create: node '%s' already exists in match clause", node.ResourceProperties.Name)
 					}
 
@@ -352,10 +382,14 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 					name := getTargetK8sResourceName(resourceTemplate, node.ResourceProperties.Name, "")
 					// create the resource
+					providerKind, err := q.providerKind(node.ResourceProperties.Kind)
+					if err != nil {
+						return *results, fmt.Errorf("error resolving resource kind %s: %v", node.ResourceProperties.Kind, err)
+					}
 					err = q.provider.CreateK8sResource(
-						node.ResourceProperties.Kind,
+						providerKind,
 						name,
-						Namespace,
+						state.namespace,
 						resourceTemplate,
 					)
 					if err != nil {
@@ -382,7 +416,8 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 			for _, item := range c.Items {
 				nodeId := strings.Split(item.JsonPath, ".")[0]
-				if resultMap[nodeId] == nil {
+				resources, ok := state.getResources(nodeId)
+				if !ok {
 					return *results, fmt.Errorf("node identifier %s not found in return clause", nodeId)
 				}
 
@@ -407,7 +442,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 				}
 				var aggregateResult interface{}
 
-				for idx, resource := range resultMap[nodeId].([]map[string]interface{}) {
+				for idx, resource := range resources {
 					// Ensure that the results.Data[nodeId] slice has enough elements to store the current resource.
 					// If the current index (idx) is beyond the current length of the slice,
 					// append a new empty map to the slice to accommodate the new data.
@@ -722,7 +757,7 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 
 			// Apply ORDER BY, LIMIT, and SKIP if specified
 			if len(c.OrderBy) > 0 || c.Limit != nil || c.Skip != nil {
-				err := q.applyColumnarOperations(c, results)
+				err := q.applyColumnarOperations(c, results, state)
 				if err != nil {
 					return *results, fmt.Errorf("error applying columnar operations: %w", err)
 				}
@@ -734,21 +769,13 @@ func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (Q
 	}
 	// build the graph
 	q.buildGraph(results)
-
-	// clear the result cache and result map
-	resultCache = make(map[string]interface{})
-	resultMap = make(map[string]interface{})
 	return *results, nil
 }
 
 // applyColumnarOperations converts QueryResult to columnar format, applies operations, and converts back
-func (q *QueryExecutor) applyColumnarOperations(c *ReturnClause, results *QueryResult) error {
+func (q *QueryExecutor) applyColumnarOperations(c *ReturnClause, results *QueryResult, state *executionState) error {
 	// Convert results to columnar format
 	columnarData := NewColumnarData()
-
-	// Determine if we need to group by pattern matches or treat each resource individually
-	// For now, we'll use a simple heuristic: if there are multiple node types with the same number of items,
-	// we'll assume they form pattern matches. Otherwise, treat each resource individually.
 
 	nodeIds := []string{}
 	nodeSizes := make(map[string]int)
@@ -764,23 +791,7 @@ func (q *QueryExecutor) applyColumnarOperations(c *ReturnClause, results *QueryR
 		}
 	}
 
-	// Check if we have potential pattern matches (multiple nodes with same size > 1)
-	hasPatternMatches := false
-	if len(nodeIds) > 1 {
-		var commonSize int = -1
-		for _, size := range nodeSizes {
-			if size > 1 {
-				if commonSize == -1 {
-					commonSize = size
-				} else if commonSize == size {
-					hasPatternMatches = true
-					break
-				}
-			}
-		}
-	}
-
-	if hasPatternMatches {
+	if state.hasPatternRows() {
 		// Process as pattern matches - each index across all nodes forms one pattern
 		maxSize := 0
 		for _, size := range nodeSizes {

--- a/pkg/core/execution_hardening_test.go
+++ b/pkg/core/execution_hardening_test.go
@@ -1,0 +1,472 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/avitaltamir/cyphernetes/pkg/provider"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type hardeningProvider struct {
+	mu        sync.Mutex
+	resources map[string][]map[string]interface{}
+	patches   []string
+	deletes   []string
+	creates   []string
+}
+
+func newHardeningProvider() *hardeningProvider {
+	return &hardeningProvider{
+		resources: map[string][]map[string]interface{}{
+			"Pod": {
+				testPod("pod-a", "default", "a", 2),
+				testPod("pod-b", "default", "b", 1),
+				testPod("pod-c", "default", "c", 3),
+			},
+			"Deployment": {
+				testDeployment("deploy-a", "default", "a", 3),
+				testDeployment("deploy-b", "default", "b", 1),
+				testDeployment("deploy-c", "default", "c", 2),
+			},
+			"Service": {
+				testService("svc-a", "default", "a"),
+				testService("svc-b", "default", "b"),
+			},
+		},
+	}
+}
+
+func (p *hardeningProvider) GetK8sResources(kind, fieldSelector, labelSelector, namespace string) (interface{}, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	source := p.resources[kind]
+	var out []map[string]interface{}
+	for _, resource := range source {
+		metadata, metadataOK := resource["metadata"].(map[string]interface{})
+		if namespace != "" && metadataOK && metadata["namespace"] != namespace {
+			continue
+		}
+		if fieldSelector != "" && !matchesSelector(resource, fieldSelector) {
+			continue
+		}
+		if labelSelector != "" && !matchesSelector(resource, labelSelector) {
+			continue
+		}
+		out = append(out, cloneResourceMap(resource))
+	}
+	return out, nil
+}
+
+func (p *hardeningProvider) DeleteK8sResources(kind, name, namespace string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.deletes = append(p.deletes, fmt.Sprintf("%s/%s/%s", kind, namespace, name))
+	return nil
+}
+
+func (p *hardeningProvider) CreateK8sResource(kind, name, namespace string, body interface{}) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.creates = append(p.creates, fmt.Sprintf("%s/%s/%s", kind, namespace, name))
+	return nil
+}
+
+func (p *hardeningProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.patches = append(p.patches, fmt.Sprintf("%s/%s/%s:%s", kind, namespace, name, string(patchJSON)))
+	return nil
+}
+
+func (p *hardeningProvider) FindGVR(kind string) (schema.GroupVersionResource, error) {
+	switch strings.ToLower(kind) {
+	case "pod", "pods":
+		return schema.GroupVersionResource{Version: "v1", Resource: "pods"}, nil
+	case "deployment", "deployments":
+		return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, nil
+	case "service", "services":
+		return schema.GroupVersionResource{Version: "v1", Resource: "services"}, nil
+	case "configmap", "configmaps":
+		return schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}, nil
+	case "secret", "secrets":
+		return schema.GroupVersionResource{Version: "v1", Resource: "secrets"}, nil
+	case "core.service":
+		return schema.GroupVersionResource{Version: "v1", Resource: "services"}, nil
+	default:
+		return schema.GroupVersionResource{}, fmt.Errorf("unknown kind %s", kind)
+	}
+}
+
+func (p *hardeningProvider) GetOpenAPIResourceSpecs() (map[string][]string, error) {
+	return map[string][]string{
+		"io.k8s.api.core.v1.Pod":        {"metadata", "spec"},
+		"io.k8s.api.apps.v1.Deployment": {"metadata", "spec"},
+		"io.k8s.api.core.v1.Service":    {"metadata", "spec"},
+	}, nil
+}
+
+func (p *hardeningProvider) CreateProviderForContext(context string) (provider.Provider, error) {
+	return p, nil
+}
+
+func (p *hardeningProvider) ToggleDryRun() {}
+
+func TestExecutionUsesSelectorAwareCacheKeys(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	result := executeTestQuery(t, executor, `MATCH (a:Pod {app: "a"}), (b:Pod {app: "b"}) RETURN a.metadata.name AS aName, b.metadata.name AS bName`)
+
+	assertFirstValue(t, result, "a", "aName", "pod-a")
+	assertFirstValue(t, result, "b", "bName", "pod-b")
+}
+
+func TestExecutionStateDoesNotLeakAfterError(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+
+	ast, err := ParseQuery(`MATCH (a:Pod {app: "a"}) SET missing.metadata.labels.foo = "bar"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(ast, "default"); err == nil {
+		t.Fatal("expected first query to fail")
+	}
+
+	result := executeTestQuery(t, executor, `MATCH (b:Pod {app: "b"}) RETURN b.metadata.name AS bName`)
+	assertFirstValue(t, result, "b", "bName", "pod-b")
+}
+
+func TestRepeatedAndConcurrentExecutionsAreIndependent(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	queries := []string{
+		`MATCH (p:Pod {app: "a"}) RETURN p.metadata.name AS name`,
+		`MATCH (p:Pod {app: "b"}) RETURN p.metadata.name AS name`,
+		`MATCH (p:Pod {app: "c"}) RETURN p.metadata.name AS name`,
+	}
+
+	for i, query := range queries {
+		result := executeTestQuery(t, executor, query)
+		assertFirstValue(t, result, "p", "name", fmt.Sprintf("pod-%c", 'a'+rune(i)))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(queries))
+	for i, query := range queries {
+		wg.Add(1)
+		go func(i int, query string) {
+			defer wg.Done()
+			ast, err := ParseQuery(query)
+			if err != nil {
+				errs <- err
+				return
+			}
+			result, err := executor.Execute(ast, "default")
+			if err != nil {
+				errs <- err
+				return
+			}
+			got := firstValue(result, "p", "name")
+			want := fmt.Sprintf("pod-%c", 'a'+rune(i))
+			if got != want {
+				errs <- fmt.Errorf("got %v, want %s", got, want)
+			}
+		}(i, query)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestKindlessRewriteUsesValidStringLiteralsForSet(t *testing.T) {
+	oldMock := mockFindPotentialKinds
+	mockFindPotentialKinds = func([]*Relationship) []string { return []string{"Pod"} }
+	defer func() { mockFindPotentialKinds = oldMock }()
+
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	ast, err := ParseQuery(`MATCH (d:Deployment)->(x) SET d.metadata.labels.note = "hello \"world\"" RETURN d.metadata.name AS name`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.rewriteQueryForKindlessNodes(ast); err != nil {
+		t.Fatalf("rewrite should render parseable literals: %v", err)
+	}
+}
+
+func TestRelationshipConsolidationDoesNotMutateGlobalRules(t *testing.T) {
+	originalRules := relationshipRules
+	relationshipRules = append([]RelationshipRule(nil), relationshipRules...)
+	defer func() { relationshipRules = originalRules }()
+
+	before := append([]MatchCriterion(nil), relationshipRules[0].MatchCriteria...)
+	provider := newHardeningProvider()
+	executor, _ := NewQueryExecutor(provider)
+	state := newExecutionState()
+	results := &QueryResult{Data: map[string]interface{}{}, Graph: Graph{}}
+	match := &MatchClause{
+		Nodes: []*NodePattern{
+			nodePattern("p", "Pod", nil),
+			nodePattern("s", "Service", nil),
+		},
+		Relationships: []*Relationship{{
+			Direction: Right,
+			LeftNode:  nodePattern("p", "Pod", nil),
+			RightNode: nodePattern("s", "Service", nil),
+		}},
+	}
+
+	_, err := executor.processRelationship(match.Relationships[0], match, results, map[string][]map[string]interface{}{}, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(before, relationshipRules[0].MatchCriteria) {
+		t.Fatal("relationship consolidation mutated global rules")
+	}
+}
+
+func TestSubMatchDoesNotMutateParsedAST(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	ast, err := ParseQuery(`MATCH (p:Pod) WHERE (p)->(:Service) RETURN p.metadata.name AS name`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := ast.Clauses[0].(*MatchClause)
+	subMatch := match.ExtraFilters[0].SubMatch
+
+	if _, err := executor.checkSubMatch(subMatch, "p", newExecutionState()); err != nil {
+		t.Fatal(err)
+	}
+	if subMatch.Nodes[0].ResourceProperties.Name != "p" {
+		t.Fatalf("submatch node name mutated to %s", subMatch.Nodes[0].ResourceProperties.Name)
+	}
+}
+
+func TestColumnarOperationsDoNotTreatUnrelatedEqualSizedResultsAsPatternRows(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	result := executeTestQuery(t, executor, `MATCH (p:Pod), (d:Deployment) RETURN p.metadata.name AS podName, d.metadata.name AS deploymentName ORDER BY podName ASC LIMIT 2`)
+
+	totalRows := 0
+	for _, rows := range result.Data {
+		if rowSlice, ok := rows.([]interface{}); ok {
+			totalRows += len(rowSlice)
+		}
+	}
+	if totalRows != 2 {
+		t.Fatalf("expected LIMIT to apply to independent rows, got %d total rows in %#v", totalRows, result.Data)
+	}
+}
+
+func TestGraphDedupesNodes(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	result := executeTestQuery(t, executor, `MATCH (p:Pod {app: "a"}) RETURN p, p.metadata.name AS name`)
+
+	seen := map[string]bool{}
+	for _, node := range result.Graph.Nodes {
+		key := node.Kind + "/" + node.Namespace + "/" + node.Name
+		if seen[key] {
+			t.Fatalf("duplicate graph node %s in %#v", key, result.Graph.Nodes)
+		}
+		seen[key] = true
+	}
+}
+
+func TestMalformedProviderResourceReturnsError(t *testing.T) {
+	provider := newHardeningProvider()
+	provider.resources["Pod"] = []map[string]interface{}{{"kind": "Pod"}}
+	executor, _ := NewQueryExecutor(provider)
+	ast, err := ParseQuery(`MATCH (p:Pod) RETURN p.metadata.name AS name`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = executor.Execute(ast, "default")
+	if err == nil || !strings.Contains(err.Error(), "resources were not loaded") && !strings.Contains(err.Error(), "metadata") {
+		t.Fatalf("expected metadata error, got %v", err)
+	}
+}
+
+func TestSetDeleteAndCreateUseExecutionState(t *testing.T) {
+	provider := newHardeningProvider()
+	executor, _ := NewQueryExecutor(provider)
+
+	executeTestQuery(t, executor, `MATCH (p:Pod {app: "a"}) SET p.metadata.labels.tier = "frontend" RETURN p.metadata.name AS name`)
+	executeTestQuery(t, executor, `MATCH (p:Pod {app: "b"}) DELETE p`)
+	executeTestQuery(t, executor, `CREATE (s:Service {"metadata":{"name":"created-svc"},"spec":{"selector":{"app":"created"}}})`)
+
+	if len(provider.patches) != 1 {
+		t.Fatalf("expected one patch, got %v", provider.patches)
+	}
+	if len(provider.deletes) != 1 {
+		t.Fatalf("expected one delete, got %v", provider.deletes)
+	}
+	if len(provider.creates) != 1 {
+		t.Fatalf("expected one create, got %v", provider.creates)
+	}
+}
+
+func executeTestQuery(t *testing.T, executor *QueryExecutor, query string) QueryResult {
+	t.Helper()
+	ast, err := ParseQuery(query)
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	result, err := executor.Execute(ast, "default")
+	if err != nil {
+		t.Fatalf("execute query: %v", err)
+	}
+	return result
+}
+
+func assertFirstValue(t *testing.T, result QueryResult, node, key string, want interface{}) {
+	t.Helper()
+	if got := firstValue(result, node, key); got != want {
+		t.Fatalf("result[%s][0][%s] = %v, want %v; full result: %#v", node, key, got, want, result.Data)
+	}
+}
+
+func firstValue(result QueryResult, node, key string) interface{} {
+	rows := result.Data[node].([]interface{})
+	return rows[0].(map[string]interface{})[key]
+}
+
+func matchesSelector(resource map[string]interface{}, selector string) bool {
+	for _, part := range strings.Split(selector, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return false
+		}
+		if key == "metadata.name" {
+			metadata, ok := resource["metadata"].(map[string]interface{})
+			if !ok {
+				return false
+			}
+			if metadata["name"] != value {
+				return false
+			}
+			continue
+		}
+		metadata, ok := resource["metadata"].(map[string]interface{})
+		if !ok {
+			return false
+		}
+		labels, _ := metadata["labels"].(map[string]interface{})
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneResourceMap(resource map[string]interface{}) map[string]interface{} {
+	data, _ := json.Marshal(resource)
+	var cloned map[string]interface{}
+	_ = json.Unmarshal(data, &cloned)
+	return cloned
+}
+
+func testPod(name, namespace, app string, replicas int) map[string]interface{} {
+	return map[string]interface{}{
+		"kind": "Pod",
+		"metadata": map[string]interface{}{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": "2026-06-07T10:00:00Z",
+			"labels": map[string]interface{}{
+				"app": app,
+			},
+		},
+		"status": map[string]interface{}{
+			"phase": "Running",
+		},
+		"spec": map[string]interface{}{
+			"replicas": replicas,
+			"values":   []interface{}{app},
+			"resources": map[string]interface{}{
+				"requests": map[string]interface{}{
+					"cpu":    "250m",
+					"memory": "128Mi",
+				},
+			},
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "main",
+					"image": "nginx",
+					"resources": map[string]interface{}{
+						"requests": map[string]interface{}{
+							"cpu":    "250m",
+							"memory": "128Mi",
+						},
+					},
+					"volumeMounts": []interface{}{
+						map[string]interface{}{"name": "config"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testDeployment(name, namespace, app string, replicas int) map[string]interface{} {
+	return map[string]interface{}{
+		"kind": "Deployment",
+		"metadata": map[string]interface{}{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": "2026-06-07T10:00:00Z",
+			"labels": map[string]interface{}{
+				"app": app,
+			},
+		},
+		"spec": map[string]interface{}{
+			"replicas": replicas,
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": app},
+			},
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{"app": app},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "main",
+							"image": "nginx",
+							"resources": map[string]interface{}{
+								"requests": map[string]interface{}{
+									"cpu":    "250m",
+									"memory": "128Mi",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testService(name, namespace, app string) map[string]interface{} {
+	return map[string]interface{}{
+		"kind": "Service",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"labels": map[string]interface{}{
+				"app": app,
+			},
+		},
+		"spec": map[string]interface{}{
+			"selector": map[string]interface{}{"app": app},
+		},
+	}
+}
+
+func nodePattern(name, kind string, properties *Properties) *NodePattern {
+	return &NodePattern{ResourceProperties: &ResourceProperties{Name: name, Kind: kind, Properties: properties}}
+}

--- a/pkg/core/execution_paths_test.go
+++ b/pkg/core/execution_paths_test.go
@@ -1,0 +1,342 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avitaltamir/cyphernetes/pkg/provider"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type unknownClause struct{}
+
+func (*unknownClause) isClause() {}
+
+func TestExecuteCoversNamespaceFiltersAndWhereBranches(t *testing.T) {
+	provider := newHardeningProvider()
+	provider.resources["Pod"] = append(provider.resources["Pod"], testPod("pod-other", "other", "other", 4))
+	executor, _ := NewQueryExecutor(provider)
+
+	oldAllNamespaces := AllNamespaces
+	AllNamespaces = true
+	allNamespacesResult := executeTestQuery(t, executor, `MATCH (p:Pod) RETURN p.metadata.name AS name ORDER BY name ASC`)
+	defer func() { AllNamespaces = oldAllNamespaces }()
+	if got := len(allNamespacesResult.Data["p"].([]interface{})); got != 4 {
+		t.Fatalf("expected all namespaces query to return 4 pods, got %d: %#v", got, allNamespacesResult.Data)
+	}
+	if AllNamespaces {
+		t.Fatal("ExecuteSingleQuery should reset AllNamespaces after use")
+	}
+
+	namespaceResult := executeTestQuery(t, executor, `MATCH (p:Pod {namespace: "other"}) RETURN p.metadata.name AS name`)
+	assertFirstValue(t, namespaceResult, "p", "name", "pod-other")
+
+	whereResult := executeTestQuery(t, executor, `MATCH (p:Pod) WHERE p.spec.replicas > 1 RETURN p.metadata.name AS name ORDER BY name ASC`)
+	if got := len(whereResult.Data["p"].([]interface{})); got != 2 {
+		t.Fatalf("expected two pods after numeric WHERE filter, got %#v", whereResult.Data)
+	}
+
+	notResult := executeTestQuery(t, executor, `MATCH (p:Pod) WHERE NOT p.metadata.name = "pod-a" RETURN p.metadata.name AS name`)
+	for _, row := range notResult.Data["p"].([]interface{}) {
+		if row.(map[string]interface{})["name"] == "pod-a" {
+			t.Fatalf("negated WHERE kept pod-a: %#v", notResult.Data)
+		}
+	}
+
+	wildcardResult := executeTestQuery(t, executor, `MATCH (p:Pod) WHERE p.spec.containers[*].image = "nginx" RETURN p.metadata.name AS name`)
+	if got := len(wildcardResult.Data["p"].([]interface{})); got != 3 {
+		t.Fatalf("expected wildcard WHERE to match default namespace pods, got %#v", wildcardResult.Data)
+	}
+
+	ast, err := ParseQuery(`MATCH (p:Pod {name: "pod-a", app: "a"}) RETURN p.metadata.name AS name`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(ast, "default"); err == nil || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("expected name selector combination error, got %v", err)
+	}
+}
+
+func TestExecuteAggregatesAndReturnShapes(t *testing.T) {
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+
+	countResult := executeTestQuery(t, executor, `MATCH (p:Pod) RETURN COUNT{p} AS totalPods`)
+	if got := countResult.Data["aggregate"].(map[string]interface{})["totalPods"]; got != 3 {
+		t.Fatalf("COUNT aggregate = %v, want 3", got)
+	}
+
+	replicasResult := executeTestQuery(t, executor, `MATCH (p:Pod) RETURN SUM{p.spec.replicas} AS totalReplicas`)
+	if got := replicasResult.Data["aggregate"].(map[string]interface{})["totalReplicas"]; got != float64(6) {
+		t.Fatalf("replica SUM = %v, want 6", got)
+	}
+
+	cpuResult := executeTestQuery(t, executor, `MATCH (p:Pod) RETURN SUM{p.spec.resources.requests.cpu} AS totalCPU`)
+	if got := cpuResult.Data["aggregate"].(map[string]interface{})["totalCPU"]; got != "750m" {
+		t.Fatalf("cpu SUM = %v, want 750m", got)
+	}
+
+	memoryResult := executeTestQuery(t, executor, `MATCH (p:Pod) RETURN SUM{p.spec.resources.requests.memory} AS totalMemory`)
+	if got := memoryResult.Data["aggregate"].(map[string]interface{})["totalMemory"]; got != "384Mi" {
+		t.Fatalf("memory SUM = %v, want 384Mi", got)
+	}
+
+	containerResult := executeTestQuery(t, executor, `MATCH (p:Pod) RETURN SUM{p.spec.containers[*].image} AS images`)
+	images := containerResult.Data["aggregate"].(map[string]interface{})["images"].([]interface{})
+	if len(images) != 3 {
+		t.Fatalf("expected container wildcard SUM to combine three images, got %#v", images)
+	}
+
+	rootResult := executeTestQuery(t, executor, `MATCH (p:Pod {app: "a"}) RETURN p`)
+	if row := rootResult.Data["p"].([]interface{})[0].(map[string]interface{}); row["$"] == nil {
+		t.Fatalf("expected root return key, got %#v", row)
+	}
+
+	nestedResult := executeTestQuery(t, executor, `MATCH (p:Pod {app: "a"}) RETURN p.metadata.labels.app`)
+	row := nestedResult.Data["p"].([]interface{})[0].(map[string]interface{})
+	if row["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["app"] != "a" {
+		t.Fatalf("expected nested return map, got %#v", row)
+	}
+
+	ast, err := ParseQuery(`MATCH (p:Pod) RETURN SUM{p.spec.values[*]} AS values`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(ast, "default"); err == nil || !strings.Contains(err.Error(), "unsupported type for SUM") {
+		t.Fatalf("expected unsupported slice SUM error, got %v", err)
+	}
+}
+
+func TestExecuteRelationshipCreateAndErrorBranches(t *testing.T) {
+	provider := newHardeningProvider()
+	executor, _ := NewQueryExecutor(provider)
+
+	executeTestQuery(t, executor, `MATCH (d:Deployment {app: "a"}) CREATE (d)->(s:Service)`)
+	if len(provider.creates) != 1 || !strings.HasPrefix(provider.creates[0], "Service/default/") {
+		t.Fatalf("expected relationship create to create a service, got %#v", provider.creates)
+	}
+
+	ast, err := ParseQuery(`MATCH (d:Deployment {app: "a"}), (s:Service {app: "a"}) CREATE (d)->(s)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(ast, "default"); err == nil || !strings.Contains(err.Error(), "both nodes") {
+		t.Fatalf("expected both-nodes-exist create error, got %v", err)
+	}
+
+	ast, err = ParseQuery(`CREATE (d:Deployment)->(s:Service)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(ast, "default"); err == nil || !strings.Contains(err.Error(), "neither node") {
+		t.Fatalf("expected neither-node create error, got %v", err)
+	}
+
+	_, err = executor.ExecuteSingleQuery(&Expression{Clauses: []Clause{&DeleteClause{NodeIds: []string{"x__exp__0"}}}}, "default")
+	if err != nil {
+		t.Fatalf("expanded delete identifiers should be skipped, got %v", err)
+	}
+
+	if _, err := executor.ExecuteSingleQuery(nil, "default"); err == nil {
+		t.Fatal("expected nil AST error")
+	}
+	if _, err := executor.ExecuteSingleQuery(&Expression{Clauses: []Clause{&unknownClause{}}}, "default"); err == nil || !strings.Contains(err.Error(), "unknown clause") {
+		t.Fatalf("expected unknown clause error, got %v", err)
+	}
+}
+
+func TestExecuteKindlessRewriteMergesExpandedResults(t *testing.T) {
+	oldMock := mockFindPotentialKinds
+	mockFindPotentialKinds = func([]*Relationship) []string { return []string{"Pod", "Deployment"} }
+	defer func() { mockFindPotentialKinds = oldMock }()
+
+	executor, _ := NewQueryExecutor(newHardeningProvider())
+	result := executeTestQuery(t, executor, `MATCH (s:Service {app: "a"})->(x) RETURN x.metadata.name AS targetName, COUNT{x} AS targetCount`)
+
+	rows, ok := result.Data["x"].([]interface{})
+	if !ok || len(rows) != 2 {
+		t.Fatalf("expected merged rows for kindless target, got %#v", result.Data)
+	}
+	names := map[interface{}]bool{}
+	for _, row := range rows {
+		names[row.(map[string]interface{})["targetName"]] = true
+	}
+	if !names["pod-a"] || !names["deploy-a"] {
+		t.Fatalf("expected pod and deployment targets, got %#v", rows)
+	}
+	if got := result.Data["aggregate"].(map[string]interface{})["targetCount"]; got != 2 {
+		t.Fatalf("merged aggregate count = %v, want 2", got)
+	}
+}
+
+func TestRelationshipInitializationDiscoversAndCachesRules(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	provider := newHardeningProvider()
+
+	oldRules := relationshipRules
+	oldPotentialKindsCache := potentialKindsCache
+	oldCleanOutput := CleanOutput
+	relationshipRules = append([]RelationshipRule(nil), relationshipRules...)
+	CleanOutput = true
+	defer func() {
+		relationshipRules = oldRules
+		potentialKindsCache = oldPotentialKindsCache
+		CleanOutput = oldCleanOutput
+	}()
+
+	specs := map[string][]string{
+		"io.k8s.api.core.v1.Pod": {
+			"spec.service.name",
+			"spec.configMap.name",
+			"spec.secretName",
+			"spec.secretName",
+		},
+		"io.k8s.api.core.v1.Service":   {"metadata.name"},
+		"io.k8s.api.core.v1.ConfigMap": {"metadata.name"},
+		"io.k8s.api.core.v1.Secret":    {"metadata.name"},
+	}
+	before := len(relationshipRules)
+	InitializeRelationships(specs, provider)
+	if len(relationshipRules) <= before {
+		t.Fatalf("expected discovered rules to be added")
+	}
+
+	var foundConfigMapRule bool
+	var foundSecretRule bool
+	for _, rule := range relationshipRules {
+		if rule.KindA == "pods" && rule.KindB == "configmaps" {
+			foundConfigMapRule = true
+		}
+		if rule.KindA == "pods" && rule.KindB == "secrets" {
+			foundSecretRule = true
+			if len(rule.MatchCriteria) < 2 {
+				t.Fatalf("expected duplicate secret fields to append criteria, got %#v", rule.MatchCriteria)
+			}
+		}
+	}
+	if !foundConfigMapRule || !foundSecretRule {
+		t.Fatalf("expected configmap and secret discovery, got %#v", relationshipRules[before:])
+	}
+
+	potentialKindsMutex.RLock()
+	podPotentials := append([]string(nil), potentialKindsCache["core.pods"]...)
+	potentialKindsMutex.RUnlock()
+	if !contains(podPotentials, "core.services") || !contains(podPotentials, "core.configmaps") {
+		t.Fatalf("expected potential kind cache to include discovered relationships, got %#v", podPotentials)
+	}
+}
+
+func TestTemporalHandlerBranches(t *testing.T) {
+	handler := NewTemporalHandler()
+	base := "2026-06-07T10:00:00Z"
+
+	exact, err := handler.EvaluateTemporalExpression(&TemporalExpression{Function: "datetime", Argument: base})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exact.Equal(time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected datetime evaluation: %v", exact)
+	}
+	plus, err := handler.EvaluateTemporalExpression(&TemporalExpression{
+		Function:  "datetime",
+		Argument:  base,
+		Operation: "+",
+		RightExpr: &TemporalExpression{Function: "duration", Argument: "PT30M"},
+	})
+	if err != nil || !plus.Equal(exact.Add(30*time.Minute)) {
+		t.Fatalf("unexpected datetime plus duration: %v %v", plus, err)
+	}
+	minus, err := handler.EvaluateTemporalExpression(&TemporalExpression{
+		Function:  "duration",
+		Argument:  "PT30M",
+		Operation: "-",
+		RightExpr: &TemporalExpression{Function: "datetime", Argument: base},
+	})
+	if err != nil || !minus.Equal(exact.Add(-30*time.Minute)) {
+		t.Fatalf("unexpected duration minus datetime: %v %v", minus, err)
+	}
+	if _, err := handler.EvaluateTemporalExpression(&TemporalExpression{Function: "datetime", Argument: "bad"}); err == nil {
+		t.Fatal("expected invalid datetime error")
+	}
+	if _, err := handler.EvaluateTemporalExpression(&TemporalExpression{Function: "datetime", Operation: "+"}); err == nil {
+		t.Fatal("expected missing right expression error")
+	}
+	if _, err := handler.EvaluateTemporalExpression(&TemporalExpression{Function: "datetime", Argument: base, Operation: "*", RightExpr: &TemporalExpression{Function: "duration", Argument: "PT1H"}}); err == nil {
+		t.Fatal("expected unsupported datetime operation error")
+	}
+	if _, err := handler.EvaluateTemporalExpression(&TemporalExpression{Function: "duration", Argument: "PT1H", Operation: "*", RightExpr: &TemporalExpression{Function: "datetime", Argument: base}}); err == nil {
+		t.Fatal("expected unsupported duration operation error")
+	}
+	if _, err := handler.EvaluateTemporalExpression(&TemporalExpression{Function: "unknown"}); err == nil {
+		t.Fatal("expected unsupported temporal function error")
+	}
+
+	for _, duration := range []string{"P1Y2M3DT4H5M6S", "PT30M"} {
+		if _, err := handler.ParseISO8601Duration(duration); err != nil {
+			t.Fatalf("expected duration %s to parse: %v", duration, err)
+		}
+	}
+	for _, duration := range []string{"", "1H", "P", "PT", "PTY", "P1H", "PT1D", "PT1X", "PT1"} {
+		if _, err := handler.ParseISO8601Duration(duration); err == nil {
+			t.Fatalf("expected invalid duration %s to fail", duration)
+		}
+	}
+
+	for _, tt := range []struct {
+		operator string
+		want     bool
+	}{
+		{"EQUALS", true},
+		{"NOT_EQUALS", false},
+		{"GREATER_THAN", false},
+		{"LESS_THAN", false},
+		{"GREATER_THAN_EQUALS", true},
+		{"LESS_THAN_EQUALS", true},
+	} {
+		got, err := handler.CompareTemporalValues(exact, &TemporalExpression{Function: "datetime", Argument: base}, tt.operator)
+		if err != nil || got != tt.want {
+			t.Fatalf("CompareTemporalValues %s = %t, %v; want %t", tt.operator, got, err, tt.want)
+		}
+	}
+	if _, err := handler.CompareTemporalValues(exact, &TemporalExpression{Function: "datetime", Argument: base}, "BAD"); err == nil {
+		t.Fatal("expected bad temporal operator error")
+	}
+}
+
+type ambiguousHardeningProvider struct {
+	*hardeningProvider
+}
+
+func (p *ambiguousHardeningProvider) FindGVR(kind string) (schema.GroupVersionResource, error) {
+	if kind == "service" {
+		return schema.GroupVersionResource{}, fmt.Errorf("ambiguous resource kind: service\ncore.service\nnetworking.service")
+	}
+	return p.hardeningProvider.FindGVR(kind)
+}
+
+func (p *ambiguousHardeningProvider) CreateProviderForContext(context string) (provider.Provider, error) {
+	return p, nil
+}
+
+func TestTryResolveGVRHandlesAmbiguousCoreResources(t *testing.T) {
+	provider := &ambiguousHardeningProvider{hardeningProvider: newHardeningProvider()}
+	executor, _ := NewQueryExecutor(provider)
+	gvr, err := tryResolveGVR(provider, "service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gvr.Resource != "services" {
+		t.Fatalf("expected core service GVR, got %#v", gvr)
+	}
+	if _, err := tryResolveGVR(provider, "missing"); err == nil {
+		t.Fatal("expected missing kind to fail")
+	}
+	key, err := executor.resourceFetchKey(nodePattern("p", "service", nil), "default", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(key, "services") {
+		t.Fatalf("expected ambiguous kind cache key to resolve core service GVR, got %q", key)
+	}
+}

--- a/pkg/core/get.go
+++ b/pkg/core/get.go
@@ -11,21 +11,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func getResourcesFromMap(filteredResults map[string][]map[string]interface{}, key string) []map[string]interface{} {
+func getResourcesFromMap(filteredResults map[string][]map[string]interface{}, key string, state *executionState) []map[string]interface{} {
 	if filtered, ok := filteredResults[key]; ok {
 		return filtered
 	}
 
-	resultMapMutex.RLock()
-	defer resultMapMutex.RUnlock()
-
-	if resources, ok := resultMap[key].([]map[string]interface{}); ok {
+	if resources, ok := state.getResources(key); ok {
 		return resources
 	}
 	return nil
 }
 
-func (q *QueryExecutor) processNodes(c *MatchClause, results *QueryResult) error {
+func (q *QueryExecutor) processNodes(c *MatchClause, results *QueryResult, state *executionState) error {
 	debugLog(fmt.Sprintf("Processing nodes, current graph nodes: %+v\n", results.Graph.Nodes))
 
 	// Track seen nodes for deduplication
@@ -51,44 +48,47 @@ func (q *QueryExecutor) processNodes(c *MatchClause, results *QueryResult) error
 			node.ResourceProperties.Kind = potentialKinds[0]
 		}
 
-		// check if the node has already been fetched
-		cacheKey, err := q.resourcePropertyName(node)
-		if err != nil {
-			return fmt.Errorf("error getting resource property name: %v", err)
-		}
-		if resultCache[cacheKey] == nil {
-			err := getNodeResources(node, q, c.ExtraFilters)
+		if _, ok := state.getResources(node.ResourceProperties.Name); !ok {
+			err := getNodeResources(node, q, c.ExtraFilters, state)
 			if err != nil {
 				return fmt.Errorf("error getting node resources >> %s", err)
 			}
-			resources := resultMap[node.ResourceProperties.Name].([]map[string]interface{})
-			for _, resource := range resources {
-				metadata, ok := resource["metadata"].(map[string]interface{})
-				if !ok {
-					continue
-				}
-				newNode := Node{
-					Id:   node.ResourceProperties.Name,
-					Kind: resource["kind"].(string),
-					Name: metadata["name"].(string),
-				}
-				if newNode.Kind != "Namespace" {
-					newNode.Namespace = getNamespaceName(metadata)
-				}
-
-				// Check if we've seen this node before
-				nodeKey := fmt.Sprintf("%s/%s", newNode.Kind, newNode.Name)
-				if !seenNodes[nodeKey] {
-					seenNodes[nodeKey] = true
-					debugLog(fmt.Sprintf("Adding new unique node from processNodes: %+v with key: %s\n", newNode, nodeKey))
-					results.Graph.Nodes = append(results.Graph.Nodes, newNode)
-				} else {
-					debugLog(fmt.Sprintf("Skipping duplicate node in processNodes: %+v with key: %s\n", newNode, nodeKey))
-				}
+		}
+		resources, ok := state.getResources(node.ResourceProperties.Name)
+		if !ok {
+			return fmt.Errorf("node %s resources were not loaded", node.ResourceProperties.Name)
+		}
+		for _, resource := range resources {
+			metadata, err := getResourceMetadata(resource)
+			if err != nil {
+				return fmt.Errorf("error reading resource metadata for node %s: %w", node.ResourceProperties.Name, err)
 			}
-		} else if resultMap[node.ResourceProperties.Name] == nil {
-			// Copy from cache using the original name
-			resultMap[node.ResourceProperties.Name] = resultCache[cacheKey]
+			kind, err := getResourceKind(resource)
+			if err != nil {
+				return fmt.Errorf("error reading resource kind for node %s: %w", node.ResourceProperties.Name, err)
+			}
+			name, err := getResourceName(metadata)
+			if err != nil {
+				return fmt.Errorf("error reading resource name for node %s: %w", node.ResourceProperties.Name, err)
+			}
+			newNode := Node{
+				Id:   node.ResourceProperties.Name,
+				Kind: kind,
+				Name: name,
+			}
+			if newNode.Kind != "Namespace" {
+				newNode.Namespace = getNamespaceName(metadata)
+			}
+
+			// Check if we've seen this node before
+			nodeKey := fmt.Sprintf("%s/%s/%s", newNode.Kind, newNode.Namespace, newNode.Name)
+			if !seenNodes[nodeKey] {
+				seenNodes[nodeKey] = true
+				debugLog(fmt.Sprintf("Adding new unique node from processNodes: %+v with key: %s\n", newNode, nodeKey))
+				results.Graph.Nodes = append(results.Graph.Nodes, newNode)
+			} else {
+				debugLog(fmt.Sprintf("Skipping duplicate node in processNodes: %+v with key: %s\n", newNode, nodeKey))
+			}
 		}
 	}
 	debugLog(fmt.Sprintf("After processNodes, graph nodes: %+v\n", results.Graph.Nodes))
@@ -96,11 +96,29 @@ func (q *QueryExecutor) processNodes(c *MatchClause, results *QueryResult) error
 }
 
 func (q *QueryExecutor) findGVR(kind string) (schema.GroupVersionResource, error) {
-	return q.provider.FindGVR(kind)
+	return tryResolveGVR(q.provider, kind)
 }
 
-func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*Filter) (err error) {
-	namespace := Namespace
+func (q *QueryExecutor) providerKind(kind string) (string, error) {
+	_, err := q.provider.FindGVR(kind)
+	if err == nil {
+		return kind, nil
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		return "", err
+	}
+	gvr, err := tryResolveGVR(q.provider, kind)
+	if err != nil {
+		return "", err
+	}
+	if gvr.Group == "" {
+		return "core." + gvr.Resource, nil
+	}
+	return gvr.Resource + "." + gvr.Group, nil
+}
+
+func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*Filter, state *executionState) (err error) {
+	namespace := state.namespace
 
 	// Create a copy of ResourceProperties
 	resourcePropertiesCopy := &ResourceProperties{}
@@ -144,26 +162,28 @@ func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*Filter) 
 		return fmt.Errorf("the 'name' selector can be used by itself or combined with 'namespace', but not with other label selectors")
 	}
 
-	// Check if the resource has already been fetched
-	cacheKey, err := q.resourcePropertyName(n)
+	// Check if the resource has already been fetched for this exact query shape.
+	cacheKey, err := q.resourceFetchKey(n, namespace, fieldSelector, labelSelector, extraFilters)
 	if err != nil {
-		return fmt.Errorf("error getting resource property name: %v", err)
+		return fmt.Errorf("error getting resource fetch key: %v", err)
 	}
 
-	// Lock for reading from cache
-	resultMapMutex.RLock()
-	cachedResult := resultCache[cacheKey]
-	resultMapMutex.RUnlock()
-
-	if cachedResult == nil {
+	if cachedResult, ok := state.cachedResources(cacheKey); !ok {
 		// Get resources using the provider
-		resources, err := q.provider.GetK8sResources(n.ResourceProperties.Kind, fieldSelector, labelSelector, namespace)
+		providerKind, err := q.providerKind(n.ResourceProperties.Kind)
+		if err != nil {
+			return fmt.Errorf("error resolving resource kind: %v", err)
+		}
+		resources, err := q.provider.GetK8sResources(providerKind, fieldSelector, labelSelector, namespace)
 		if err != nil {
 			return fmt.Errorf("error getting resources: %v", err)
 		}
 
 		// Apply extra filters from WHERE clause
-		resourceList := resources.([]map[string]interface{})
+		resourceList, ok := resources.([]map[string]interface{})
+		if !ok {
+			return fmt.Errorf("provider returned %T for %s, expected []map[string]interface{}", resources, n.ResourceProperties.Kind)
+		}
 		var filtered []map[string]interface{}
 
 		var subMatches []*SubMatch
@@ -281,7 +301,7 @@ func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*Filter) 
 			}
 
 			// for each submatch, run checkSubMatch
-			subMatchResults, err := q.checkSubMatch(subMatch, n.ResourceProperties.Name)
+			subMatchResults, err := q.checkSubMatch(subMatch, n.ResourceProperties.Name, state)
 			if err != nil {
 				return fmt.Errorf("error checking submatch: %v", err)
 			}
@@ -304,16 +324,10 @@ func getNodeResources(n *NodePattern, q *QueryExecutor, extraFilters []*Filter) 
 			filtered = newFiltered
 		}
 
-		// Lock for writing to both maps
-		resultMapMutex.Lock()
-		resultCache[cacheKey] = filtered
-		resultMap[n.ResourceProperties.Name] = filtered
-		resultMapMutex.Unlock()
+		state.cacheResources(cacheKey, n.ResourceProperties.Name, filtered)
 	} else {
 		// If we found it in cache, just copy to resultMap
-		resultMapMutex.Lock()
-		resultMap[n.ResourceProperties.Name] = cachedResult
-		resultMapMutex.Unlock()
+		state.setResources(n.ResourceProperties.Name, cachedResult)
 	}
 
 	return nil
@@ -365,13 +379,16 @@ func compareValues(resourceValue, filterValue interface{}, operator string) bool
 	return false
 }
 
-func (q *QueryExecutor) checkSubMatch(subMatch *SubMatch, referenceNodeName string) (map[string][]map[string]interface{}, error) {
+func (q *QueryExecutor) checkSubMatch(subMatch *SubMatch, referenceNodeName string, state *executionState) (map[string][]map[string]interface{}, error) {
+	subMatch = cloneSubMatch(subMatch)
+	subState := newExecutionState()
+	subState.namespace = state.namespace
+
 	// Create temporary results and filtered results maps
 	tempResults := QueryResult{
 		Data: make(map[string]interface{}),
 	}
 	filteredResults := make(map[string][]map[string]interface{})
-	resultMap := make(map[string][]map[string]interface{})
 
 	for _, node := range subMatch.Nodes {
 		if node.ResourceProperties.Name == referenceNodeName {
@@ -399,13 +416,12 @@ func (q *QueryExecutor) checkSubMatch(subMatch *SubMatch, referenceNodeName stri
 	// Get resources for the reference node first
 	for _, node := range matchClause.Nodes {
 		if node.ResourceProperties.Name == "_ref_"+subMatch.ReferenceNodeName {
-			err := getNodeResources(node, q, nil)
+			err := getNodeResources(node, q, nil, subState)
 			if err != nil {
 				return nil, err
 			}
 			// Initialize filteredResults and resultMap with the reference node's resources
-			filteredResults[node.ResourceProperties.Name] = getResourcesFromMap(filteredResults, node.ResourceProperties.Name)
-			resultMap[node.ResourceProperties.Name] = getResourcesFromMap(filteredResults, node.ResourceProperties.Name)
+			filteredResults[node.ResourceProperties.Name] = getResourcesFromMap(filteredResults, node.ResourceProperties.Name, subState)
 			break
 		}
 	}
@@ -417,20 +433,20 @@ func (q *QueryExecutor) checkSubMatch(subMatch *SubMatch, referenceNodeName stri
 		for _, rel := range matchClause.Relationships {
 			// Get resources for nodes that aren't the reference node
 			if rel.LeftNode.ResourceProperties.Name != "_ref_"+subMatch.ReferenceNodeName {
-				err := getNodeResources(rel.LeftNode, q, nil)
+				err := getNodeResources(rel.LeftNode, q, nil, subState)
 				if err != nil {
 					return nil, err
 				}
 			}
 			if rel.RightNode.ResourceProperties.Name != "_ref_"+subMatch.ReferenceNodeName {
-				err := getNodeResources(rel.RightNode, q, nil)
+				err := getNodeResources(rel.RightNode, q, nil, subState)
 				if err != nil {
 					return nil, err
 				}
 			}
 
 			// Process the relationship and update filteredResults
-			filtered, err := q.processRelationship(rel, matchClause, &tempResults, filteredResults)
+			filtered, err := q.processRelationship(rel, matchClause, &tempResults, filteredResults, subState)
 			if err != nil {
 				return nil, err
 			}
@@ -451,7 +467,7 @@ func (q *QueryExecutor) checkSubMatch(subMatch *SubMatch, referenceNodeName stri
 
 		// Update resultMap with filtered results for the next pass
 		for k, v := range filteredResults {
-			resultMap[k] = v
+			subState.setResources(k, v)
 		}
 	}
 

--- a/pkg/core/graph.go
+++ b/pkg/core/graph.go
@@ -6,6 +6,12 @@ func (q *QueryExecutor) buildGraph(result *QueryResult) {
 	debugLog(fmt.Sprintln("Building graph"))
 	debugLog(fmt.Sprintf("Initial nodes: %+v\n", result.Graph.Nodes))
 
+	nodes := []Node{}
+	nodeMap := make(map[string]bool)
+	for _, node := range result.Graph.Nodes {
+		addGraphNode(&nodes, nodeMap, node)
+	}
+
 	// Process nodes from result data
 	for key, resources := range result.Data {
 		resourcesSlice, ok := resources.([]interface{})
@@ -17,16 +23,16 @@ func (q *QueryExecutor) buildGraph(result *QueryResult) {
 			if !ok {
 				continue
 			}
-			metadata, ok := resourceMap["metadata"].(map[string]interface{})
-			if !ok {
+			metadata, err := getResourceMetadata(resourceMap)
+			if err != nil {
 				continue
 			}
-			name, ok := metadata["name"].(string)
-			if !ok {
+			name, err := getResourceName(metadata)
+			if err != nil {
 				continue
 			}
-			kind, ok := resourceMap["kind"].(string)
-			if !ok {
+			kind, err := getResourceKind(resourceMap)
+			if err != nil {
 				continue
 			}
 			node := Node{
@@ -38,9 +44,10 @@ func (q *QueryExecutor) buildGraph(result *QueryResult) {
 				node.Namespace = getNamespaceName(metadata)
 			}
 			debugLog(fmt.Sprintf("Adding node from result data: %+v\n", node))
-			result.Graph.Nodes = append(result.Graph.Nodes, node)
+			addGraphNode(&nodes, nodeMap, node)
 		}
 	}
+	result.Graph.Nodes = nodes
 
 	// Process edges
 	var edges []Edge
@@ -56,6 +63,14 @@ func (q *QueryExecutor) buildGraph(result *QueryResult) {
 		}
 	}
 	result.Graph.Edges = edges
+}
+
+func addGraphNode(nodes *[]Node, seen map[string]bool, node Node) {
+	key := fmt.Sprintf("%s/%s/%s", node.Kind, node.Namespace, node.Name)
+	if !seen[key] {
+		seen[key] = true
+		*nodes = append(*nodes, node)
+	}
 }
 
 func getNamespaceName(metadata map[string]interface{}) string {

--- a/pkg/core/helper_hardening_test.go
+++ b/pkg/core/helper_hardening_test.go
@@ -1,0 +1,518 @@
+package core
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestCacheExecutorAndMultiContextHelpers(t *testing.T) {
+	provider := newHardeningProvider()
+
+	oldOnce := once
+	oldExecutor := executorInstance
+	oldContextExecutors := contextExecutors
+	oldGVRCache := GvrCache
+	oldResourceSpecs := ResourceSpecs
+	oldCleanOutput := CleanOutput
+	oldRelationships := relationships
+	oldPotentialKindsCache := potentialKindsCache
+	defer func() {
+		once = oldOnce
+		executorInstance = oldExecutor
+		contextExecutors = oldContextExecutors
+		GvrCache = oldGVRCache
+		ResourceSpecs = oldResourceSpecs
+		CleanOutput = oldCleanOutput
+		relationships = oldRelationships
+		potentialKindsCache = oldPotentialKindsCache
+	}()
+
+	once = sync.Once{}
+	executorInstance = nil
+	contextExecutors = nil
+	GvrCache = nil
+	ResourceSpecs = nil
+	CleanOutput = true
+
+	if err := InitGVRCache(provider); err != nil {
+		t.Fatal(err)
+	}
+	if GvrCache == nil {
+		t.Fatal("expected InitGVRCache to initialize cache")
+	}
+	if err := InitResourceSpecs(provider); err != nil {
+		t.Fatal(err)
+	}
+	if len(ResourceSpecs) == 0 {
+		t.Fatal("expected resource specs to be loaded")
+	}
+
+	executor := GetQueryExecutorInstance(provider)
+	if executor == nil {
+		t.Fatal("expected singleton executor")
+	}
+	if executor.Provider() != provider {
+		t.Fatal("singleton executor returned wrong provider")
+	}
+	specs, err := executor.GetOpenAPIResourceSpecs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs["io.k8s.api.core.v1.Pod"][0] != "metadata" {
+		t.Fatalf("unexpected specs: %#v", specs)
+	}
+
+	contextExecutor, err := GetContextQueryExecutor("west")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again, err := GetContextQueryExecutor("west"); err != nil || again != contextExecutor {
+		t.Fatalf("expected cached context executor, got %#v err %v", again, err)
+	}
+
+	ast := &Expression{
+		Contexts: []string{"east", "west"},
+		Clauses: []Clause{
+			&MatchClause{
+				Nodes: []*NodePattern{nodePattern("p", "Pod", &Properties{PropertyList: []*Property{{Key: "app", Value: "a"}}})},
+			},
+			&ReturnClause{Items: []*ReturnItem{{JsonPath: "p.metadata.name", Alias: "podName"}}},
+		},
+	}
+	result, err := ExecuteMultiContextQuery(ast, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFirstValue(t, result, "east_p", "podName", "pod-a")
+	assertFirstValue(t, result, "west_p", "podName", "pod-a")
+}
+
+func TestPrefixVariablesCoversAllClauseTypes(t *testing.T) {
+	ast := &Expression{
+		Contexts: []string{"ctx"},
+		Clauses: []Clause{
+			&MatchClause{
+				Nodes: []*NodePattern{
+					nodePattern("p", "Pod", nil),
+					nodePattern("s", "Service", nil),
+				},
+				Relationships: []*Relationship{{
+					Direction: Right,
+					LeftNode:  nodePattern("p", "Pod", nil),
+					RightNode: nodePattern("s", "Service", nil),
+				}},
+				ExtraFilters: []*Filter{{
+					Type:         "KeyValuePair",
+					KeyValuePair: &KeyValuePair{Key: "p.metadata.name", Value: "pod-a", Operator: "="},
+				}},
+			},
+			&ReturnClause{Items: []*ReturnItem{{JsonPath: "p.metadata.name", Alias: "podName"}}},
+			&SetClause{KeyValuePairs: []*KeyValuePair{{Key: "p.metadata.labels.team", Value: "core"}}},
+			&DeleteClause{NodeIds: []string{"p"}},
+			&CreateClause{
+				Nodes: []*NodePattern{nodePattern("n", "Service", nil)},
+				Relationships: []*Relationship{{
+					Direction: Right,
+					LeftNode:  nodePattern("n", "Service", nil),
+					RightNode: nodePattern("p", "Pod", nil),
+				}},
+			},
+		},
+	}
+
+	modified := prefixVariables(ast, "ctx")
+	match := modified.Clauses[0].(*MatchClause)
+	if match.Nodes[0].ResourceProperties.Name != "ctx_p" ||
+		match.Relationships[0].LeftNode.ResourceProperties.Name != "ctx_p" ||
+		match.ExtraFilters[0].KeyValuePair.Key != "ctx_p.metadata.name" {
+		t.Fatalf("match clause was not prefixed: %#v", match)
+	}
+	if modified.Clauses[1].(*ReturnClause).Items[0].JsonPath != "ctx_p.metadata.name" {
+		t.Fatalf("return clause was not prefixed: %#v", modified.Clauses[1])
+	}
+	if modified.Clauses[2].(*SetClause).KeyValuePairs[0].Key != "ctx_p.metadata.labels.team" {
+		t.Fatalf("set clause was not prefixed: %#v", modified.Clauses[2])
+	}
+	if modified.Clauses[3].(*DeleteClause).NodeIds[0] != "ctx_p" {
+		t.Fatalf("delete clause was not prefixed: %#v", modified.Clauses[3])
+	}
+	create := modified.Clauses[4].(*CreateClause)
+	if create.Nodes[0].ResourceProperties.Name != "ctx_n" ||
+		create.Relationships[0].RightNode.ResourceProperties.Name != "ctx_p" {
+		t.Fatalf("create clause was not prefixed: %#v", create)
+	}
+}
+
+func TestPatchJsonPathAndSetHelpers(t *testing.T) {
+	patches := createCompatiblePatch([]string{"metadata", "labels", "app.kubernetes.io/name"}, "api")
+	if patchPath(t, patches, 1) != "/metadata/labels/app.kubernetes.io~1name" {
+		t.Fatalf("unexpected dotted label patch: %#v", patches)
+	}
+
+	patches = createCompatiblePatch([]string{"metadata", "annotations", "team"}, "core")
+	if patchPath(t, patches, 1) != "/metadata/annotations/team" {
+		t.Fatalf("unexpected annotation patch: %#v", patches)
+	}
+
+	patches = createCompatiblePatch([]string{"spec", "template", "spec", "containers[0]", "resources", "limits", "cpu"}, "500m")
+	if patchPath(t, patches, 1) != "/spec/template/spec/containers/0/resources/limits/cpu" {
+		t.Fatalf("unexpected container patch: %#v", patches)
+	}
+
+	patches = createCompatiblePatch([]string{"spec", "replicas"}, 3)
+	if patchPath(t, patches, 0) != "/spec/replicas" {
+		t.Fatalf("unexpected regular patch: %#v", patches)
+	}
+
+	resource := testPod("pod-a", "default", "a", 1)
+	resource["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["app.kubernetes.io/name"] = "api"
+	if parts := splitEscapedPath("metadata.labels.app\\.kubernetes\\.io/name"); !reflect.DeepEqual(parts, []string{"metadata", "labels", "app.kubernetes.io/name"}) {
+		t.Fatalf("unexpected escaped split: %#v", parts)
+	}
+	if value, err := JsonPathCompileAndLookup(resource, "$.metadata.labels.app\\.kubernetes\\.io/name"); err != nil || value != "api" {
+		t.Fatalf("escaped jsonpath lookup = %v, %v", value, err)
+	}
+
+	containers := resource["spec"].(map[string]interface{})["containers"].([]interface{})
+	containers = append(containers, map[string]interface{}{"name": "sidecar", "image": "redis"})
+	resource["spec"].(map[string]interface{})["containers"] = containers
+	if !evaluateWildcardPath(resource, "$.spec.containers[*].image", "redis", "=") {
+		t.Fatal("expected wildcard path to match sidecar image")
+	}
+	if evaluateWildcardPath(resource, "$.spec.containers[*].image", "postgres", "=") {
+		t.Fatal("unexpected wildcard path match")
+	}
+	if err := applyWildcardUpdate(resource, "$.spec.containers[*].image", "busybox"); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range resource["spec"].(map[string]interface{})["containers"].([]interface{}) {
+		if item.(map[string]interface{})["image"] != "busybox" {
+			t.Fatalf("wildcard update missed container: %#v", resource)
+		}
+	}
+
+	if err := setValueAtPath(resource, ".metadata.annotations.owner", "platform"); err != nil {
+		t.Fatal(err)
+	}
+	metadata := resource["metadata"].(map[string]interface{})
+	if metadata["annotations"].(map[string]interface{})["owner"] != "platform" {
+		t.Fatalf("setValueAtPath did not update annotations: %#v", resource)
+	}
+
+	updateResultMap(resource, []string{"spec", "nodeSelector", "disk"}, "ssd")
+	if resource["spec"].(map[string]interface{})["nodeSelector"].(map[string]interface{})["disk"] != "ssd" {
+		t.Fatalf("updateResultMap did not create nested path: %#v", resource)
+	}
+	if err := setValueAtPath([]interface{}{}, ".metadata.name", "bad"); err == nil {
+		t.Fatal("expected setValueAtPath to reject non-map data")
+	}
+
+	provider := newHardeningProvider()
+	executor, _ := NewQueryExecutor(provider)
+	patchJSON, _ := json.Marshal([]map[string]interface{}{{"op": "add", "path": "/metadata/labels/team", "value": "core"}})
+	if err := executor.PatchK8sResource(resource, patchJSON); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.patches) != 1 || !strings.Contains(provider.patches[0], "/metadata/labels/team") {
+		t.Fatalf("patch was not recorded: %#v", provider.patches)
+	}
+}
+
+func TestColumnarAndOrderingHelpers(t *testing.T) {
+	cd := NewColumnarData()
+	cd.AddRow(map[string]interface{}{"name": "pod-b", "score": 2}, "p", 1)
+	cd.AddRow(map[string]interface{}{"name": "pod-a", "score": 1}, "p", 0)
+	cd.AddRow(map[string]interface{}{"name": "svc-a", "score": 9}, "s", 0)
+
+	if patterns := cd.GetPatternMatches(); len(patterns) != 2 {
+		t.Fatalf("expected two pattern groups, got %#v", patterns)
+	}
+	nestedCD := NewColumnarData()
+	nestedCD.AddRow(map[string]interface{}{"metadata": map[string]interface{}{"name": "nested"}}, "p", 0)
+	if got := nestedCD.extractFieldValue("p.metadata.name", nestedCD.Rows[0], "p"); got != "nested" {
+		t.Fatalf("unexpected extracted nested field: %v", got)
+	}
+	if got := navigateJSONPath(map[string]interface{}{"metadata": map[string]interface{}{"name": "pod-a"}}, "metadata.name"); got != "pod-a" {
+		t.Fatalf("unexpected navigated value: %v", got)
+	}
+	if navigateJSONPath(map[string]interface{}{"metadata": "bad"}, "metadata.name") != nil {
+		t.Fatal("expected invalid nested path to return nil")
+	}
+
+	if err := cd.OrderBy([]*OrderByItem{{Field: "name", Direction: "ASC"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := cd.Rows[0][0]; got != "pod-a" {
+		t.Fatalf("unexpected first sorted row: %#v", cd.Rows)
+	}
+	cd.Skip(1)
+	if len(cd.Rows) != 1 {
+		t.Fatalf("expected one row after skip, got %#v", cd.Rows)
+	}
+	cd.Limit(0)
+	if len(cd.Rows) != 0 {
+		t.Fatalf("expected empty rows after zero limit, got %#v", cd.Rows)
+	}
+	cd.Skip(5)
+
+	aggregate := NewColumnarData()
+	aggregate.AddRow(map[string]interface{}{"count": 3}, "aggregate", -1)
+	if result := aggregate.ConvertToQueryResult(); result["aggregate"].(map[string]interface{})["count"] != 3 {
+		t.Fatalf("unexpected aggregate conversion: %#v", result)
+	}
+	aggregate.Limit(5)
+
+	for _, tt := range []struct {
+		a, b interface{}
+		want int
+	}{
+		{nil, nil, 0},
+		{nil, "x", -1},
+		{"b", "a", 1},
+		{int64(1), int64(2), -1},
+		{1.5, 1.0, 1},
+		{false, true, -1},
+		{"10", 2, 1},
+	} {
+		if got := compareOrderValues(tt.a, tt.b); got != tt.want {
+			t.Fatalf("compareOrderValues(%v, %v) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestRelationshipStateAndComparisonHelpers(t *testing.T) {
+	provider := newHardeningProvider()
+
+	oldRules := relationshipRules
+	relationshipRules = append([]RelationshipRule(nil), relationshipRules...)
+	defer func() { relationshipRules = oldRules }()
+
+	rules := findRelationshipRulesBetweenKinds("services", "pods")
+	if len(rules) == 0 || rules[0].Relationship != ServiceExposePod {
+		t.Fatalf("expected service/pod rule first, got %#v", rules)
+	}
+
+	ruleA := RelationshipRule{
+		KindA:        "pod",
+		KindB:        "service",
+		Relationship: "A",
+		MatchCriteria: []MatchCriterion{{
+			FieldA:         "$.metadata.labels",
+			FieldB:         "$.spec.selector",
+			ComparisonType: ContainsAll,
+		}},
+	}
+	ruleB := RelationshipRule{
+		KindA:        "pods",
+		KindB:        "services",
+		Relationship: "B",
+		MatchCriteria: []MatchCriterion{{
+			FieldA:         "$.metadata.name",
+			FieldB:         "$.metadata.name",
+			ComparisonType: ExactMatch,
+		}},
+	}
+	if !areRelatedRules(ruleA, ruleB, provider) {
+		t.Fatal("expected singular and plural rules to relate")
+	}
+	consolidated := consolidateMatchingRules([]RelationshipRule{ruleA, ruleB, ruleB}, provider)
+	if len(consolidated.MatchCriteria) != 2 {
+		t.Fatalf("expected unique criteria to be consolidated, got %#v", consolidated.MatchCriteria)
+	}
+	if got := consolidateMatchingRules(nil, provider); got.Relationship != "" {
+		t.Fatalf("expected empty consolidated rule, got %#v", got)
+	}
+
+	podGVR, _ := provider.FindGVR("pods")
+	serviceGVR, _ := provider.FindGVR("services")
+	gvrCache := map[string]schema.GroupVersionResource{
+		"pods":     podGVR,
+		"services": serviceGVR,
+	}
+	if idx, ok := findExistingRelationshipRule("pods", "services", gvrCache); !ok || idx < 0 {
+		t.Fatalf("expected existing pod/service rule, got idx=%d ok=%t", idx, ok)
+	}
+	if _, ok := findExistingRelationshipRule("pods", "missing", gvrCache); ok {
+		t.Fatal("did not expect relationship rule for missing GVR")
+	}
+
+	relationshipsMutex.Lock()
+	oldRelationships := relationships
+	relationships = map[string][]string{"pods": {"services"}}
+	relationshipsMutex.Unlock()
+	gotRelationships := GetRelationships()
+	defer func() {
+		relationshipsMutex.Lock()
+		relationships = oldRelationships
+		relationshipsMutex.Unlock()
+	}()
+	if !reflect.DeepEqual(gotRelationships["pods"], []string{"services"}) {
+		t.Fatalf("unexpected relationships: %#v", gotRelationships)
+	}
+
+	if !containsResource([]map[string]interface{}{testPod("pod-a", "default", "a", 1)}, testPod("pod-a", "default", "b", 1)) {
+		t.Fatal("expected containsResource to match by name and namespace")
+	}
+	if containsResource([]map[string]interface{}{{"kind": "Pod"}}, testPod("pod-a", "default", "a", 1)) {
+		t.Fatal("did not expect malformed resource to match")
+	}
+}
+
+func TestStateAggregateFilterAndUtilityHelpers(t *testing.T) {
+	state := newExecutionState()
+	pods := []map[string]interface{}{testPod("pod-a", "default", "a", 1)}
+	state.cacheResources("pods:a", "p", pods)
+	if !state.copyCachedResources("pods:a", "copy") {
+		t.Fatal("expected cached resources to be copied")
+	}
+	if state.copyCachedResources("pods:missing", "copy") {
+		t.Fatal("did not expect missing cache copy")
+	}
+	if got, err := requireResourceList(pods, "p"); err != nil || len(got) != 1 {
+		t.Fatalf("unexpected resource list result: %v, %v", got, err)
+	}
+	if _, err := requireResourceList("bad", "p"); err == nil {
+		t.Fatal("expected resource list type error")
+	}
+
+	filters := []*Filter{
+		{Type: "SubMatch", SubMatch: &SubMatch{ReferenceNodeName: "p", IsNegated: true, Nodes: []*NodePattern{nodePattern("p", "Pod", nil)}}},
+		nil,
+		{Type: "KeyValuePair", KeyValuePair: &KeyValuePair{Key: "p.metadata.name", Value: "pod-a", Operator: "=", IsNegated: false}},
+	}
+	signature := filterSignature(filters)
+	if !strings.Contains(signature, "kv:p.metadata.name:=:false") || !strings.Contains(signature, "sub:p:true:1:0") {
+		t.Fatalf("unexpected filter signature: %s", signature)
+	}
+
+	subMatch := &SubMatch{
+		IsNegated:         true,
+		ReferenceNodeName: "p",
+		Nodes:             []*NodePattern{nodePattern("p", "Pod", &Properties{PropertyList: []*Property{nil, {Key: "app", Value: "a"}}})},
+		Relationships: []*Relationship{{
+			Direction: Right,
+			LeftNode:  nodePattern("p", "Pod", nil),
+			RightNode: nodePattern("s", "Service", nil),
+		}},
+	}
+	cloned := cloneSubMatch(subMatch)
+	cloned.Nodes[0].ResourceProperties.Name = "changed"
+	if subMatch.Nodes[0].ResourceProperties.Name != "p" || cloned.Relationships[0].LeftNode != cloned.Nodes[0] {
+		t.Fatalf("clone did not preserve independent node graph: original=%#v clone=%#v", subMatch, cloned)
+	}
+	if cloneSubMatch(nil) != nil || cloneRelationship(nil, nil) != nil || cloneNodePattern(nil) != nil || cloneResourceProperties(nil) != nil {
+		t.Fatal("nil clone helpers should return nil")
+	}
+
+	if result, filter, err := convertToComparableTypes(1, "2"); err != nil || result != float64(1) || filter != float64(2) {
+		t.Fatalf("unexpected numeric conversion: %v %v %v", result, filter, err)
+	}
+	if result, filter, err := convertToComparableTypes("abc", true); err != nil || result != "abc" || filter != "true" {
+		t.Fatalf("unexpected string fallback conversion: %v %v %v", result, filter, err)
+	}
+	if result, filter, err := convertToComparableTypes("abc", nil); err != nil || result != "abc" || filter != nil {
+		t.Fatalf("unexpected nil conversion: %v %v %v", result, filter, err)
+	}
+	for _, v := range []interface{}{float32(1.5), int32(2), int64(3), "4"} {
+		if _, err := toFloat64(v); err != nil {
+			t.Fatalf("expected %T to convert: %v", v, err)
+		}
+	}
+	if _, err := toFloat64(true); err == nil {
+		t.Fatal("expected bool conversion to fail")
+	}
+
+	for _, tt := range []struct {
+		resource interface{}
+		filter   interface{}
+		operator string
+		want     bool
+	}{
+		{"a", "a", "EQUALS", true},
+		{"a", "b", "!=", true},
+		{3.0, 2.0, ">", true},
+		{1.0, 2.0, "<", true},
+		{2.0, 2.0, ">=", true},
+		{2.0, 2.0, "<=", true},
+		{"running", "run", "CONTAINS", true},
+		{"pod-123", `pod-\d+`, "REGEX_COMPARE", true},
+		{"pod", "[", "REGEX_COMPARE", false},
+	} {
+		if got := compareValues(tt.resource, tt.filter, tt.operator); got != tt.want {
+			t.Fatalf("compareValues(%v, %v, %s) = %t", tt.resource, tt.filter, tt.operator, got)
+		}
+	}
+
+	if !isResourceInList(testPod("pod-a", "default", "a", 1), pods) {
+		t.Fatal("expected resource to be found in list")
+	}
+	if extractKindFromSchemaName("io.k8s.api.core.v1.Pod") != "Pod" || extractKindFromSchemaName("") != "" {
+		t.Fatal("unexpected schema kind extraction")
+	}
+	if !contains([]string{"pod", "service"}, "service") || contains([]string{"pod"}, "deployment") {
+		t.Fatal("contains returned unexpected result")
+	}
+	if doubled := Map([]int{1, 2}, func(item int, index int) int { return item*2 + index }); !reflect.DeepEqual(doubled, []int{2, 5}) {
+		t.Fatalf("unexpected map result: %#v", doubled)
+	}
+	if value, ok := Find([]string{"pod", "service"}, func(item string) bool { return strings.HasPrefix(item, "ser") }); !ok || value != "service" {
+		t.Fatalf("unexpected find hit: %s %t", value, ok)
+	}
+	if value, ok := Find([]string{"pod"}, func(item string) bool { return item == "service" }); ok || value != "" {
+		t.Fatalf("unexpected find miss: %s %t", value, ok)
+	}
+	(&MatchClause{}).isClause()
+	(&CreateClause{}).isClause()
+	(&SetClause{}).isClause()
+	(&DeleteClause{}).isClause()
+	(&ReturnClause{}).isClause()
+}
+
+func TestLexerSettersAndQueryLiteralHelpers(t *testing.T) {
+	lexer := NewLexer("MATCH")
+	if lexer.Peek() == 0 {
+		t.Fatal("expected lexer peek to see input")
+	}
+	lexer.SetParsingContexts(true)
+	lexer.SetParsingJsonData(false)
+	lexer.SetParsingJsonPath(true)
+	if !lexer.inContexts || !lexer.inJsonData || !lexer.isInJsonPath {
+		t.Fatalf("lexer flags not set: %#v", lexer)
+	}
+
+	if (&QueryExpandedError{ExpandedQuery: "MATCH (p:Pod)"}).Error() != "query expanded to: MATCH (p:Pod)" {
+		t.Fatal("unexpected query expanded error string")
+	}
+	for _, tt := range []struct {
+		value interface{}
+		want  string
+	}{
+		{"hello \"world\"", `"hello \"world\""`},
+		{true, "true"},
+		{false, "false"},
+		{nil, "null"},
+		{3, "3"},
+	} {
+		if got := renderQueryLiteral(tt.value); got != tt.want {
+			t.Fatalf("renderQueryLiteral(%#v) = %s, want %s", tt.value, got, tt.want)
+		}
+	}
+}
+
+func patchPath(t *testing.T, patches []interface{}, index int) string {
+	t.Helper()
+	patch, ok := patches[index].(map[string]interface{})
+	if !ok {
+		t.Fatalf("patch %d has unexpected type: %#v", index, patches[index])
+	}
+	path, ok := patch["path"].(string)
+	if !ok {
+		t.Fatalf("patch %d has no string path: %#v", index, patch)
+	}
+	return path
+}

--- a/pkg/core/jsonpath.go
+++ b/pkg/core/jsonpath.go
@@ -17,10 +17,11 @@ func applyWildcardUpdateRecursive(data interface{}, parts []string, depth int, v
 		return setValueAtPath(data, parts[depth], value)
 	}
 
-	// Get the array at current level
-	currentPath := parts[depth]
-	if !strings.HasSuffix(currentPath, ".") {
-		currentPath += "."
+	// Get the array at current level. The wildcard split leaves the array
+	// path before [*]; render it as a valid JSONPath without a dangling dot.
+	currentPath := strings.TrimSuffix(parts[depth], ".")
+	if !strings.HasPrefix(currentPath, "$") {
+		currentPath = "$." + strings.TrimPrefix(currentPath, ".")
 	}
 	array, err := JsonPathCompileAndLookup(data, currentPath)
 	if err != nil {

--- a/pkg/core/kind_resolution.go
+++ b/pkg/core/kind_resolution.go
@@ -44,12 +44,12 @@ func FindPotentialKinds(sourceKind string, provider provider.Provider) ([]string
 
 	for _, rule := range rules {
 		// Get proper plural forms using FindGVR
-		gvrA, err := provider.FindGVR(rule.KindA)
+		gvrA, err := tryResolveGVR(provider, rule.KindA)
 		if err != nil {
 			debugLog("Error getting GVR for %s: %v", rule.KindA, err)
 			continue
 		}
-		gvrB, err := provider.FindGVR(rule.KindB)
+		gvrB, err := tryResolveGVR(provider, rule.KindB)
 		if err != nil {
 			debugLog("Error getting GVR for %s: %v", rule.KindB, err)
 			continue

--- a/pkg/core/query.go
+++ b/pkg/core/query.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -153,13 +154,7 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(expr *Expression) (*Express
 
 							for j := 0; j < len(potentialKinds); j++ {
 								varName := fmt.Sprintf("%s__exp__%d", nodeName, j)
-								var valueStr string
-								switch v := filter.Value.(type) {
-								case string:
-									valueStr = fmt.Sprintf("\"%s\"", v)
-								default:
-									valueStr = fmt.Sprintf("%v", v)
-								}
+								valueStr := renderQueryLiteral(filter.Value)
 								// Map operator names to symbols
 								operator := filter.Operator
 								switch operator {
@@ -246,26 +241,14 @@ func (q *QueryExecutor) rewriteQueryForKindlessNodes(expr *Expression) (*Express
 							for j := 0; j < len(potentialKinds); j++ {
 								varName := fmt.Sprintf("%s__exp__%d", parts[0], j)
 								setPath := fmt.Sprintf("%s.%s", varName, parts[1])
-								var valueStr string
-								switch v := kvp.Value.(type) {
-								case string:
-									valueStr = fmt.Sprintf("\"%s\"", v)
-								default:
-									valueStr = fmt.Sprintf("%v", v)
-								}
+								valueStr := renderQueryLiteral(kvp.Value)
 								setParts = append(setParts, fmt.Sprintf("%s = %s", setPath, valueStr))
 							}
 						} else {
 							// If the node is not kindless, just use it as is
 							varName := fmt.Sprintf("%s__exp__0", parts[0])
 							setPath := fmt.Sprintf("%s.%s", varName, parts[1])
-							var valueStr string
-							switch v := kvp.Value.(type) {
-							case string:
-								valueStr = fmt.Sprintf("'%s'", v)
-							default:
-								valueStr = fmt.Sprintf("%v", v)
-							}
+							valueStr := renderQueryLiteral(kvp.Value)
 							setParts = append(setParts, fmt.Sprintf("%s = %s", setPath, valueStr))
 						}
 					}
@@ -337,4 +320,20 @@ func isKindless(nodeName string, kindlessNodes []*NodePattern) bool {
 		}
 	}
 	return false
+}
+
+func renderQueryLiteral(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return strconv.Quote(v)
+	case nil:
+		return "null"
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }

--- a/pkg/core/relationship.go
+++ b/pkg/core/relationship.go
@@ -706,7 +706,7 @@ func consolidateMatchingRules(rules []RelationshipRule, provider provider.Provid
 	return consolidated
 }
 
-func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, results *QueryResult, filteredResults map[string][]map[string]interface{}) (bool, error) {
+func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, results *QueryResult, filteredResults map[string][]map[string]interface{}, state *executionState) (bool, error) {
 	debugLog(fmt.Sprintf("Processing relationship: %+v\n", rel))
 
 	// Determine relationship type and fetch related resources
@@ -749,6 +749,7 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 	}
 
 	// Find all possible rules between these kinds
+	var selectedRule *RelationshipRule
 	if relType == "" {
 		matchingRules := findRelationshipRulesBetweenKinds(leftKind.Resource, rightKind.Resource)
 
@@ -763,36 +764,34 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 			consolidatedRule := consolidateMatchingRules(matchingRules, q.provider)
 			// Use the consolidated rule's relationship type
 			relType = consolidatedRule.Relationship
-
-			// Replace the rule in relationshipRules (temporarily, just for this query)
-			for i, rule := range relationshipRules {
-				if rule.Relationship == relType {
-					// Create a copy to avoid modifying the global rule
-					tempRule := relationshipRules[i]
-					tempRule.MatchCriteria = consolidatedRule.MatchCriteria
-					relationshipRules[i] = tempRule
-					break
-				}
-			}
+			selectedRule = &consolidatedRule
 		} else {
 			// Just one rule, use its relationship type
 			relType = matchingRules[0].Relationship
+			ruleCopy := matchingRules[0]
+			selectedRule = &ruleCopy
 		}
 
 		debugLog("Selected relationship type %s from %d possible rules between %s and %s",
 			relType, len(matchingRules), leftKind.Resource, rightKind.Resource)
 	}
 
-	rule, err := findRuleByRelationshipType(relType)
-	if err != nil {
-		return false, fmt.Errorf("error determining relationship type >> %s", err)
+	var rule RelationshipRule
+	if selectedRule != nil {
+		rule = *selectedRule
+	} else {
+		var err error
+		rule, err = findRuleByRelationshipType(relType)
+		if err != nil {
+			return false, fmt.Errorf("error determining relationship type >> %s", err)
+		}
 	}
 
 	// Fetch and process related resources
 	for _, node := range c.Nodes {
 		if node.ResourceProperties.Name == rel.LeftNode.ResourceProperties.Name || node.ResourceProperties.Name == rel.RightNode.ResourceProperties.Name {
 			if results.Data[node.ResourceProperties.Name] == nil {
-				err := getNodeResources(node, q, c.ExtraFilters)
+				err := getNodeResources(node, q, c.ExtraFilters, state)
 				if err != nil {
 					return false, err
 				}
@@ -803,22 +802,20 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 	var resourcesA, resourcesB []map[string]interface{}
 	var filteredDirection Direction
 
-	resultMapMutex.RLock()
 	if rule.KindA == rightKind.Resource {
-		resourcesA = getResourcesFromMap(filteredResults, rel.RightNode.ResourceProperties.Name)
-		resourcesB = getResourcesFromMap(filteredResults, rel.LeftNode.ResourceProperties.Name)
+		resourcesA = getResourcesFromMap(filteredResults, rel.RightNode.ResourceProperties.Name, state)
+		resourcesB = getResourcesFromMap(filteredResults, rel.LeftNode.ResourceProperties.Name, state)
 		filteredDirection = Left
 	} else if rule.KindA == leftKind.Resource {
-		resourcesA = getResourcesFromMap(filteredResults, rel.LeftNode.ResourceProperties.Name)
-		resourcesB = getResourcesFromMap(filteredResults, rel.RightNode.ResourceProperties.Name)
+		resourcesA = getResourcesFromMap(filteredResults, rel.LeftNode.ResourceProperties.Name, state)
+		resourcesB = getResourcesFromMap(filteredResults, rel.RightNode.ResourceProperties.Name, state)
 		filteredDirection = Right
 	} else {
-		resultMapMutex.RUnlock()
 		return false, fmt.Errorf("relationship rule not found for %s and %s", rel.LeftNode.ResourceProperties.Kind, rel.RightNode.ResourceProperties.Kind)
 	}
-	resultMapMutex.RUnlock()
 
 	matchedResources := applyRelationshipRule(resourcesA, resourcesB, rule, filteredDirection)
+	state.markPatternRows()
 
 	// Add nodes and edges based on the matched resources
 	rightResources := matchedResources["right"].([]map[string]interface{})
@@ -826,35 +823,51 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 
 	// Add nodes
 	for _, rightResource := range rightResources {
-		if metadata, ok := rightResource["metadata"].(map[string]interface{}); ok {
-			if name, ok := metadata["name"].(string); ok {
-				node := Node{
-					Id:   rel.RightNode.ResourceProperties.Name,
-					Kind: rightResource["kind"].(string),
-					Name: name,
-				}
-				if node.Kind != "Namespace" {
-					node.Namespace = getNamespaceName(metadata)
-				}
-				results.Graph.Nodes = append(results.Graph.Nodes, node)
-			}
+		metadata, err := getResourceMetadata(rightResource)
+		if err != nil {
+			return false, fmt.Errorf("error reading right resource metadata: %w", err)
 		}
+		name, err := getResourceName(metadata)
+		if err != nil {
+			return false, fmt.Errorf("error reading right resource name: %w", err)
+		}
+		kind, err := getResourceKind(rightResource)
+		if err != nil {
+			return false, fmt.Errorf("error reading right resource kind: %w", err)
+		}
+		node := Node{
+			Id:   rel.RightNode.ResourceProperties.Name,
+			Kind: kind,
+			Name: name,
+		}
+		if node.Kind != "Namespace" {
+			node.Namespace = getNamespaceName(metadata)
+		}
+		results.Graph.Nodes = append(results.Graph.Nodes, node)
 	}
 
 	for _, leftResource := range leftResources {
-		if metadata, ok := leftResource["metadata"].(map[string]interface{}); ok {
-			if name, ok := metadata["name"].(string); ok {
-				node := Node{
-					Id:   rel.LeftNode.ResourceProperties.Name,
-					Kind: leftResource["kind"].(string),
-					Name: name,
-				}
-				if node.Kind != "Namespace" {
-					node.Namespace = getNamespaceName(metadata)
-				}
-				results.Graph.Nodes = append(results.Graph.Nodes, node)
-			}
+		metadata, err := getResourceMetadata(leftResource)
+		if err != nil {
+			return false, fmt.Errorf("error reading left resource metadata: %w", err)
 		}
+		name, err := getResourceName(metadata)
+		if err != nil {
+			return false, fmt.Errorf("error reading left resource name: %w", err)
+		}
+		kind, err := getResourceKind(leftResource)
+		if err != nil {
+			return false, fmt.Errorf("error reading left resource kind: %w", err)
+		}
+		node := Node{
+			Id:   rel.LeftNode.ResourceProperties.Name,
+			Kind: kind,
+			Name: name,
+		}
+		if node.Kind != "Namespace" {
+			node.Namespace = getNamespaceName(metadata)
+		}
+		results.Graph.Nodes = append(results.Graph.Nodes, node)
 	}
 
 	// Process edges
@@ -863,8 +876,32 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 			// Check if these resources actually match according to the criteria
 			for _, criterion := range rule.MatchCriteria {
 				if matchByCriterion(rightResource, leftResource, criterion) || matchByCriterion(leftResource, rightResource, criterion) {
-					rightNodeId := fmt.Sprintf("%s/%s", rightResource["kind"].(string), rightResource["metadata"].(map[string]interface{})["name"].(string))
-					leftNodeId := fmt.Sprintf("%s/%s", leftResource["kind"].(string), leftResource["metadata"].(map[string]interface{})["name"].(string))
+					rightKind, err := getResourceKind(rightResource)
+					if err != nil {
+						return false, fmt.Errorf("error reading right resource kind: %w", err)
+					}
+					leftKind, err := getResourceKind(leftResource)
+					if err != nil {
+						return false, fmt.Errorf("error reading left resource kind: %w", err)
+					}
+					rightMetadata, err := getResourceMetadata(rightResource)
+					if err != nil {
+						return false, fmt.Errorf("error reading right resource metadata: %w", err)
+					}
+					leftMetadata, err := getResourceMetadata(leftResource)
+					if err != nil {
+						return false, fmt.Errorf("error reading left resource metadata: %w", err)
+					}
+					rightName, err := getResourceName(rightMetadata)
+					if err != nil {
+						return false, fmt.Errorf("error reading right resource name: %w", err)
+					}
+					leftName, err := getResourceName(leftMetadata)
+					if err != nil {
+						return false, fmt.Errorf("error reading left resource name: %w", err)
+					}
+					rightNodeId := fmt.Sprintf("%s/%s", rightKind, rightName)
+					leftNodeId := fmt.Sprintf("%s/%s", leftKind, leftName)
 					results.Graph.Edges = append(results.Graph.Edges, Edge{
 						From: rightNodeId,
 						To:   leftNodeId,
@@ -881,22 +918,8 @@ func (q *QueryExecutor) processRelationship(rel *Relationship, c *MatchClause, r
 	filteredResults[rel.RightNode.ResourceProperties.Name] = matchedResources["right"].([]map[string]interface{})
 	filteredResults[rel.LeftNode.ResourceProperties.Name] = matchedResources["left"].([]map[string]interface{})
 
-	resultMapMutex.Lock()
-	if resultMap[rel.RightNode.ResourceProperties.Name] != nil {
-		if len(resultMap[rel.RightNode.ResourceProperties.Name].([]map[string]interface{})) > len(matchedResources["right"].([]map[string]interface{})) {
-			resultMap[rel.RightNode.ResourceProperties.Name] = matchedResources["right"]
-		}
-	} else {
-		resultMap[rel.RightNode.ResourceProperties.Name] = matchedResources["right"]
-	}
-	if resultMap[rel.LeftNode.ResourceProperties.Name] != nil {
-		if len(resultMap[rel.LeftNode.ResourceProperties.Name].([]map[string]interface{})) > len(matchedResources["left"].([]map[string]interface{})) {
-			resultMap[rel.LeftNode.ResourceProperties.Name] = matchedResources["left"]
-		}
-	} else {
-		resultMap[rel.LeftNode.ResourceProperties.Name] = matchedResources["left"]
-	}
-	resultMapMutex.Unlock()
+	state.setResourcesIfMoreSelective(rel.RightNode.ResourceProperties.Name, matchedResources["right"].([]map[string]interface{}))
+	state.setResourcesIfMoreSelective(rel.LeftNode.ResourceProperties.Name, matchedResources["left"].([]map[string]interface{}))
 
 	return filteredA || filteredB, nil
 }

--- a/pkg/core/resource_helpers.go
+++ b/pkg/core/resource_helpers.go
@@ -1,0 +1,27 @@
+package core
+
+import "fmt"
+
+func getResourceMetadata(resource map[string]interface{}) (map[string]interface{}, error) {
+	metadata, ok := resource["metadata"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("metadata is not a map")
+	}
+	return metadata, nil
+}
+
+func getResourceName(metadata map[string]interface{}) (string, error) {
+	name, ok := metadata["name"].(string)
+	if !ok || name == "" {
+		return "", fmt.Errorf("metadata.name is not a non-empty string")
+	}
+	return name, nil
+}
+
+func getResourceKind(resource map[string]interface{}) (string, error) {
+	kind, ok := resource["kind"].(string)
+	if !ok || kind == "" {
+		return "", fmt.Errorf("kind is not a non-empty string")
+	}
+	return kind, nil
+}

--- a/pkg/core/set.go
+++ b/pkg/core/set.go
@@ -226,11 +226,15 @@ func (q *QueryExecutor) PatchK8sResource(resource map[string]interface{}, patchJ
 		namespace = ns.(string)
 	}
 	kind := resource["kind"].(string)
+	providerKind, err := q.providerKind(kind)
+	if err != nil {
+		return fmt.Errorf("error resolving resource kind %s: %v", kind, err)
+	}
 
-	return q.provider.PatchK8sResource(kind, name, namespace, patchJSON)
+	return q.provider.PatchK8sResource(providerKind, name, namespace, patchJSON)
 }
 
-func (q *QueryExecutor) handleSetClause(c *SetClause) error {
+func (q *QueryExecutor) handleSetClause(c *SetClause, state *executionState) error {
 	debugLog("Processing %d key-value pairs\n", len(c.KeyValuePairs))
 
 	for i, kvp := range c.KeyValuePairs {
@@ -241,7 +245,7 @@ func (q *QueryExecutor) handleSetClause(c *SetClause) error {
 		resultMapKey := parts[0]
 		debugLog("Resource name: %s", resultMapKey)
 
-		resources, ok := resultMap[resultMapKey].([]map[string]interface{})
+		resources, ok := state.getResources(resultMapKey)
 		if !ok {
 			return fmt.Errorf("could not find resources for node %s in MATCH clause", resultMapKey)
 		}
@@ -249,7 +253,7 @@ func (q *QueryExecutor) handleSetClause(c *SetClause) error {
 
 		// Find the matching node from the stored match nodes
 		var nodeKind string
-		for _, node := range q.matchNodes {
+		for _, node := range state.matchNodes {
 			if node.ResourceProperties.Name == resultMapKey {
 				nodeKind = node.ResourceProperties.Kind
 				debugLog("Found kind %s for node %s", nodeKind, resultMapKey)
@@ -307,7 +311,11 @@ func (q *QueryExecutor) handleSetClause(c *SetClause) error {
 				debugLog("Patch JSON: %s", string(patchJSON))
 				debugLog("Current resource state: %+v", resource)
 
-				err = q.provider.PatchK8sResource(nodeKind, name, namespace, patchJSON)
+				providerKind, err := q.providerKind(nodeKind)
+				if err != nil {
+					return fmt.Errorf("error resolving resource kind %s: %v", nodeKind, err)
+				}
+				err = q.provider.PatchK8sResource(providerKind, name, namespace, patchJSON)
 				if err != nil {
 					return fmt.Errorf("error patching resource: %s", err)
 				}
@@ -315,7 +323,7 @@ func (q *QueryExecutor) handleSetClause(c *SetClause) error {
 
 				// Verify the patch was applied
 				debugLog("Verifying patch was applied")
-				updatedResource, err := q.provider.GetK8sResources(nodeKind, fmt.Sprintf("metadata.name=%s", name), "", namespace)
+				updatedResource, err := q.provider.GetK8sResources(providerKind, fmt.Sprintf("metadata.name=%s", name), "", namespace)
 				if err != nil {
 					return fmt.Errorf("error verifying patch: %s", err)
 				}

--- a/pkg/core/state.go
+++ b/pkg/core/state.go
@@ -1,0 +1,215 @@
+package core
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type executionState struct {
+	mu          sync.RWMutex
+	resultMap   map[string]interface{}
+	resultCache map[string]interface{}
+	matchNodes  []*NodePattern
+	namespace   string
+	graphNodes  map[string]bool
+	graphEdges  map[string]bool
+	hasPatterns bool
+}
+
+func newExecutionState() *executionState {
+	return &executionState{
+		resultMap:   make(map[string]interface{}),
+		resultCache: make(map[string]interface{}),
+		graphNodes:  make(map[string]bool),
+		graphEdges:  make(map[string]bool),
+	}
+}
+
+func (s *executionState) getResources(key string) ([]map[string]interface{}, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return resourcesFromValue(s.resultMap[key])
+}
+
+func (s *executionState) setResources(key string, resources []map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resultMap[key] = resources
+}
+
+func (s *executionState) deleteResources(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.resultMap, key)
+}
+
+func (s *executionState) cachedResources(key string) ([]map[string]interface{}, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return resourcesFromValue(s.resultCache[key])
+}
+
+func (s *executionState) cacheResources(cacheKey, resultKey string, resources []map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resultCache[cacheKey] = resources
+	s.resultMap[resultKey] = resources
+}
+
+func (s *executionState) copyCachedResources(cacheKey, resultKey string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	resources, ok := resourcesFromValue(s.resultCache[cacheKey])
+	if !ok {
+		return false
+	}
+	s.resultMap[resultKey] = resources
+	return true
+}
+
+func (s *executionState) setResourcesIfMoreSelective(key string, resources []map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := resourcesFromValue(s.resultMap[key])
+	if !ok || len(current) > len(resources) {
+		s.resultMap[key] = resources
+	}
+}
+
+func (s *executionState) markPatternRows() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hasPatterns = true
+}
+
+func (s *executionState) hasPatternRows() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.hasPatterns
+}
+
+func resourcesFromValue(value interface{}) ([]map[string]interface{}, bool) {
+	resources, ok := value.([]map[string]interface{})
+	return resources, ok
+}
+
+func requireResourceList(value interface{}, node string) ([]map[string]interface{}, error) {
+	resources, ok := resourcesFromValue(value)
+	if !ok {
+		return nil, fmt.Errorf("expected resources for node %s, got %T", node, value)
+	}
+	return resources, nil
+}
+
+func filterSignature(filters []*Filter) string {
+	if len(filters) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(filters))
+	for _, filter := range filters {
+		if filter == nil {
+			continue
+		}
+		switch filter.Type {
+		case "KeyValuePair":
+			if filter.KeyValuePair != nil {
+				kvp := filter.KeyValuePair
+				parts = append(parts, fmt.Sprintf("kv:%s:%s:%t:%#v", kvp.Key, kvp.Operator, kvp.IsNegated, kvp.Value))
+			}
+		case "SubMatch":
+			if filter.SubMatch != nil {
+				parts = append(parts, fmt.Sprintf("sub:%s:%t:%d:%d", filter.SubMatch.ReferenceNodeName, filter.SubMatch.IsNegated, len(filter.SubMatch.Nodes), len(filter.SubMatch.Relationships)))
+			}
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+func cloneSubMatch(subMatch *SubMatch) *SubMatch {
+	if subMatch == nil {
+		return nil
+	}
+	nodes := make([]*NodePattern, len(subMatch.Nodes))
+	nodesByName := make(map[string]*NodePattern, len(subMatch.Nodes))
+	for i, node := range subMatch.Nodes {
+		nodes[i] = cloneNodePattern(node)
+		if nodes[i] != nil && nodes[i].ResourceProperties != nil {
+			nodesByName[nodes[i].ResourceProperties.Name] = nodes[i]
+		}
+	}
+
+	relationships := make([]*Relationship, len(subMatch.Relationships))
+	for i, rel := range subMatch.Relationships {
+		relationships[i] = cloneRelationship(rel, nodesByName)
+	}
+
+	return &SubMatch{
+		IsNegated:         subMatch.IsNegated,
+		Nodes:             nodes,
+		Relationships:     relationships,
+		ReferenceNodeName: subMatch.ReferenceNodeName,
+	}
+}
+
+func cloneRelationship(rel *Relationship, nodesByName map[string]*NodePattern) *Relationship {
+	if rel == nil {
+		return nil
+	}
+	left := cloneNodePattern(rel.LeftNode)
+	right := cloneNodePattern(rel.RightNode)
+	if rel.LeftNode != nil && rel.LeftNode.ResourceProperties != nil {
+		if node, ok := nodesByName[rel.LeftNode.ResourceProperties.Name]; ok {
+			left = node
+		}
+	}
+	if rel.RightNode != nil && rel.RightNode.ResourceProperties != nil {
+		if node, ok := nodesByName[rel.RightNode.ResourceProperties.Name]; ok {
+			right = node
+		}
+	}
+	return &Relationship{
+		ResourceProperties: cloneResourceProperties(rel.ResourceProperties),
+		Direction:          rel.Direction,
+		LeftNode:           left,
+		RightNode:          right,
+	}
+}
+
+func cloneNodePattern(node *NodePattern) *NodePattern {
+	if node == nil {
+		return nil
+	}
+	return &NodePattern{
+		ResourceProperties: cloneResourceProperties(node.ResourceProperties),
+		IsAnonymous:        node.IsAnonymous,
+	}
+}
+
+func cloneResourceProperties(props *ResourceProperties) *ResourceProperties {
+	if props == nil {
+		return nil
+	}
+	cloned := &ResourceProperties{
+		Name:     props.Name,
+		Kind:     props.Kind,
+		JsonData: props.JsonData,
+	}
+	if props.Properties != nil {
+		cloned.Properties = &Properties{
+			PropertyList: make([]*Property, len(props.Properties.PropertyList)),
+		}
+		for i, prop := range props.Properties.PropertyList {
+			if prop == nil {
+				continue
+			}
+			cloned.Properties.PropertyList[i] = &Property{
+				Key:   prop.Key,
+				Value: prop.Value,
+			}
+		}
+	}
+	return cloned
+}

--- a/pkg/provider/apiserver/provider.go
+++ b/pkg/provider/apiserver/provider.go
@@ -214,7 +214,7 @@ func (p *APIServerProvider) fetchResources(kind, fieldSelector, labelSelector, n
 	p.resourceMutex.RLock()
 	defer p.resourceMutex.RUnlock()
 
-	gvr, err := p.FindGVR(kind)
+	gvr, err := p.findGVRForResourceOperation(kind)
 	if err != nil {
 		return nil, err
 	}
@@ -246,6 +246,19 @@ func (p *APIServerProvider) fetchResources(kind, fieldSelector, labelSelector, n
 		converted = append(converted, u.UnstructuredContent())
 	}
 	return converted, nil
+}
+
+func (p *APIServerProvider) findGVRForResourceOperation(kind string) (schema.GroupVersionResource, error) {
+	gvr, err := p.FindGVR(kind)
+	if err == nil {
+		return gvr, nil
+	}
+	if strings.Contains(err.Error(), "ambiguous") {
+		if coreGVR, coreErr := p.FindGVR("core." + kind); coreErr == nil {
+			return coreGVR, nil
+		}
+	}
+	return schema.GroupVersionResource{}, err
 }
 
 // Move the FindGVR implementation from k8s_client.go here
@@ -340,7 +353,7 @@ func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string) err
 	p.resourceMutex.Lock()
 	defer p.resourceMutex.Unlock()
 
-	gvr, err := p.FindGVR(kind)
+	gvr, err := p.findGVRForResourceOperation(kind)
 	if err != nil {
 		return err
 	}
@@ -381,7 +394,7 @@ func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body
 	p.resourceMutex.Lock()
 	defer p.resourceMutex.Unlock()
 
-	gvr, err := p.FindGVR(kind)
+	gvr, err := p.findGVRForResourceOperation(kind)
 	if err != nil {
 		return err
 	}
@@ -430,7 +443,7 @@ func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body
 }
 
 func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte) error {
-	gvr, err := p.FindGVR(kind)
+	gvr, err := p.findGVRForResourceOperation(kind)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- move core query execution state into per-execution storage to prevent stale/cross-query leakage
- make resource caching selector-aware and harden relationship/kindless/submatch handling
- add defensive provider resource helpers and expanded pkg/core regression coverage
- add an 80% pkg/core coverage gate to Makefile and PR CI

## Verification
- go test ./pkg/core
- go test -race ./pkg/core
- make core-coverage

## Notes
- Full make test still fails locally in existing cmd/cyphernetes shell prompt/syntax-highlighter tests; pkg/core and the new coverage gate pass.