### PR TITLE
Add Vi mode toggle to shell

### DIFF
--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -93,6 +93,12 @@ func filterInput(r rune) (rune, bool) {
 	return r, true
 }
 
+func toggleVimMode(rl *readline.Instance) bool {
+	vimMode := !rl.IsVimMode()
+	rl.SetVimMode(vimMode)
+	return vimMode
+}
+
 func shellPrompt() string {
 	ns := core.Namespace
 	color := getPromptColor(ns)
@@ -485,6 +491,8 @@ func initAndRunShell(_ *cobra.Command, _ []string) {
 			// Toggle multi-line input mode
 			multiLineInput = !multiLineInput
 			fmt.Printf("Multi-line input mode: %t\n", multiLineInput)
+		} else if input == "\\v" {
+			fmt.Printf("Vi mode: %t\n", toggleVimMode(rl))
 		} else if input == "\\g" {
 			// Toggle graph output
 			disableGraphOutput = !disableGraphOutput
@@ -870,6 +878,7 @@ func printHelp() {
 %s
 %s
 %s
+%s
 
 %s
 %s
@@ -895,6 +904,7 @@ func printHelp() {
 		formatCmd("\\g, \\graph", "Toggle graph output"),
 		formatCmd("\\gl, \\graph-layout", "Toggle graph layout direction"),
 		formatCmd("\\m, \\multiline", "Toggle multiline input mode"),
+		formatCmd("\\v", "Toggle Vi keybindings"),
 		formatCmd("\\r, \\raw", "Toggle raw JSON output"),
 		formatCmd("\\dr, \\dry-run", "Toggle dry-run mode"),
 		formatCmd("\\rr, \\relationship-rules", "List available relationship rules"),

--- a/cmd/cyphernetes/shell_test.go
+++ b/cmd/cyphernetes/shell_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -117,6 +119,32 @@ func TestFilterInput(t *testing.T) {
 				t.Errorf("filterInput(%v) = %v, want %v", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestToggleVimMode(t *testing.T) {
+	var out bytes.Buffer
+	rl, err := readline.NewEx(&readline.Config{
+		Stdin:          io.NopCloser(strings.NewReader("")),
+		Stdout:         &out,
+		Stderr:         &out,
+		FuncIsTerminal: func() bool { return false },
+		FuncMakeRaw:    func() error { return nil },
+		FuncExitRaw:    func() error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("failed to create readline instance: %v", err)
+	}
+	defer rl.Close()
+
+	if rl.IsVimMode() {
+		t.Fatal("expected Vim mode to be disabled by default")
+	}
+	if enabled := toggleVimMode(rl); !enabled || !rl.IsVimMode() {
+		t.Fatalf("expected first toggle to enable Vim mode, got enabled=%t IsVimMode=%t", enabled, rl.IsVimMode())
+	}
+	if enabled := toggleVimMode(rl); enabled || rl.IsVimMode() {
+		t.Fatalf("expected second toggle to disable Vim mode, got enabled=%t IsVimMode=%t", enabled, rl.IsVimMode())
 	}
 }
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -39,6 +39,7 @@ Available shell commands:
 * `exit` - Exit the shell.
 * `\n <namespace>|all` - Set the namespace context for the shell to either `<namespace>` or all namespaces.
 * `\m` - Toggle multiline mode (execute query on ';').
+* `\v` - Toggle Vi keybindings.
 * `\g` - Toggle graph mode (print graph as ASCII art).
 * `\gl` - Toggle graph layout (Left to Right or Top to Bottom).
 * `\d` - Print debug information.

--- a/web/src/components/ResultsDisplay.tsx
+++ b/web/src/components/ResultsDisplay.tsx
@@ -25,7 +25,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ result, error, message,
   const [displayedResult, setDisplayedResult] = useState<string>('');
   const [showNotification, setShowNotification] = useState<boolean>(false);
   const [notificationMessage, setNotificationMessage] = useState<string>('');
-  const notificationTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const notificationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const notificationIdRef = useRef<number>(0);
   const lastResultRef = useRef<string | null>(null);
 

--- a/web/src/components/__tests__/QueryInput.test.tsx
+++ b/web/src/components/__tests__/QueryInput.test.tsx
@@ -5,7 +5,7 @@ import QueryInput from '../QueryInput';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+globalThis.fetch = mockFetch as unknown as typeof fetch;
 
 describe('QueryInput Component', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- add `\v` in `cyphernetes shell` to toggle readline Vi keybindings
- document the shell Vi toggle in the CLI docs
- fix web TypeScript build errors so `make` succeeds with the current toolchain

## Verification
- `go test ./cmd/cyphernetes -run TestToggleVimMode -count=1`
- `cd web && pnpm run build`
- `cd web && pnpm test`
- `make`

## Notes
- `make` still prints Node/Vite deprecation warnings from dependencies, but it exits successfully.