### PR TITLE
feat(operator): add dry-run mode to DynamicOperator (#201)

### DIFF
--- a/cmd/cyphernetes/api.go
+++ b/cmd/cyphernetes/api.go
@@ -54,9 +54,7 @@ func handleQuery(c *gin.Context) {
 	}
 
 	// Create the API server provider
-	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
-		DryRun: DryRun,
-	})
+	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{})
 	if err != nil {
 		fmt.Printf("Provider error: %v\n", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Error creating provider: %v", err)})
@@ -80,7 +78,7 @@ func handleQuery(c *gin.Context) {
 	}
 
 	// Execute the query
-	result, err := executor.Execute(ast, core.Namespace)
+	result, err := executor.Execute(ast, core.Namespace, core.WithDryRun(DryRun))
 	if err != nil {
 		fmt.Printf("Execution error: %v\n", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Error executing query: %v", err)})
@@ -209,10 +207,10 @@ func handleSetConfig(c *gin.Context) {
 		return
 	}
 
-	// Update dry run mode if provided
+	// Update dry run mode if provided. Dry-run is applied per query execution
+	// (see WithDryRun where queries are run), so we only store the flag here.
 	if config.DryRun != nil {
 		DryRun = *config.DryRun
-		executor.Provider().ToggleDryRun()
 	}
 
 	// Return the updated configuration

--- a/cmd/cyphernetes/query.go
+++ b/cmd/cyphernetes/query.go
@@ -60,7 +60,6 @@ var queryCmd = &cobra.Command{
 func runQuery(args []string, w io.Writer) {
 	// Create the API server provider
 	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
-		DryRun:    DryRun,
 		QuietMode: true,
 	})
 	if err != nil {
@@ -102,7 +101,7 @@ func runQuery(args []string, w io.Writer) {
 	}
 
 	// Execute the query against the Kubernetes API.
-	results, err := executeMethod(executor, ast, core.Namespace)
+	results, err := executeMethod(executor, ast, core.Namespace, core.WithDryRun(DryRun))
 	if err != nil {
 		fmt.Fprintln(w, "Error executing query: ", err)
 		return

--- a/cmd/cyphernetes/query_test.go
+++ b/cmd/cyphernetes/query_test.go
@@ -121,7 +121,7 @@ func TestRunQuery(t *testing.T) {
 				newQueryExecutor = func(p provider.Provider) (*core.QueryExecutor, error) {
 					return &core.QueryExecutor{}, nil
 				}
-				executeMethod = func(_ *core.QueryExecutor, expr *core.Expression, namespace string) (core.QueryResult, error) {
+				executeMethod = func(_ *core.QueryExecutor, expr *core.Expression, namespace string, _ ...core.ExecuteOption) (core.QueryResult, error) {
 					return tt.mockExecute(expr, namespace)
 				}
 			}

--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -56,10 +56,8 @@ var ShellCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		showSplash()
 
-		// Create provider with dry-run config
-		provider, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
-			DryRun: DryRun,
-		})
+		// Create the API server provider
+		provider, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{})
 		if err != nil {
 			fmt.Printf("Error creating provider: %v\n", err)
 			return
@@ -506,8 +504,8 @@ func initAndRunShell(_ *cobra.Command, _ []string) {
 				fmt.Println("Graph layout: Top to Bottom")
 			}
 		} else if input == "\\dr" {
-			// Toggle dry-run mode
-			executor.Provider().ToggleDryRun()
+			// Toggle dry-run mode. Dry-run is applied per query execution
+			// (see WithDryRun below), so we only need to flip the flag here.
 			DryRun = !DryRun
 			fmt.Printf("Dry-run mode: %t\n\n", DryRun)
 		} else if input == "\\rr" {
@@ -698,7 +696,7 @@ func executeStatement(query string) (string, error) {
 		return "", fmt.Errorf("error parsing query >> %s", err)
 	}
 
-	results, err := executor.Execute(ast, core.Namespace)
+	results, err := executor.Execute(ast, core.Namespace, core.WithDryRun(DryRun))
 	if err != nil {
 		return "", fmt.Errorf("error executing query >> %s", err)
 	}

--- a/cmd/cyphernetes/web.go
+++ b/cmd/cyphernetes/web.go
@@ -84,9 +84,7 @@ func runWeb(cmd *cobra.Command, args []string) {
 	url := fmt.Sprintf("http://localhost:%s", port)
 
 	// Create the API server provider
-	providerConfig := &apiserver.APIServerProviderConfig{
-		DryRun: DryRun,
-	}
+	providerConfig := &apiserver.APIServerProviderConfig{}
 	provider, err := apiserver.NewAPIServerProviderWithOptions(providerConfig)
 	if err != nil {
 		fmt.Printf("Error creating provider: %v\n", err)

--- a/cmd/kubectl-cypher/main.go
+++ b/cmd/kubectl-cypher/main.go
@@ -62,7 +62,6 @@ var rootCmd = &cobra.Command{
 func runQuery(args []string, w io.Writer) {
 	// Create the API server provider
 	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
-		DryRun:    DryRun,
 		QuietMode: true,
 	})
 	if err != nil {
@@ -109,7 +108,7 @@ func runQuery(args []string, w io.Writer) {
 	}
 
 	// Execute the query against the Kubernetes API.
-	results, err := executor.Execute(ast, core.Namespace)
+	results, err := executor.Execute(ast, core.Namespace, core.WithDryRun(DryRun))
 	if err != nil {
 		fmt.Fprintln(w, "Error executing query: ", err)
 		return

--- a/docs/docs/operator.md
+++ b/docs/docs/operator.md
@@ -88,4 +88,33 @@ You can easily template `DynamicOperator` resources using the cyphernetes cli:
 cyphernetes operator create my-operator --on-create "MATCH (n) RETURN n" | kubectl apply -f -
 ```
 
+## Dry-run mode
+
+A `DynamicOperator` can be created in dry-run mode by setting `dryRun: true` (it defaults to `false`).
+In dry-run mode the operator still watches the target resource and evaluates the
+`onCreate`/`onUpdate`/`onDelete` queries, but every mutation is sent to the Kubernetes API
+with the dry-run option, so **nothing is actually persisted**. The operator also skips its own
+side effects in this mode (it does not add finalizers or owner references to your resources).
+
+This lets you preview what an operator *would* do — visible in the operator logs as
+`Dry run mode: would create/patch/delete ...` — before enabling it for real.
+
+```yaml
+apiVersion: cyphernetes-operator.cyphernet.es/v1
+kind: DynamicOperator
+metadata:
+  name: ingress-activator-operator
+  namespace: default
+spec:
+  resourceKind: deployments
+  namespace: default
+  dryRun: true # preview only; no changes are persisted
+  onUpdate: |
+    MATCH (d:Deployment {name: "{{$.metadata.name}}"})->(s:Service)->(i:Ingress)
+    WHERE d.spec.replicas = 0
+    SET i.spec.ingressClassName = "inactive";
+```
+
+To make the operator apply changes for real, remove the `dryRun` field or set it to `false`.
+
 

--- a/operator/api/v1/dynamicoperator_types.go
+++ b/operator/api/v1/dynamicoperator_types.go
@@ -22,6 +22,14 @@ type DynamicOperatorSpec struct {
 
 	// OnDelete is the Cyphernetes query to execute when a resource is deleted
 	OnDelete string `json:"onDelete,omitempty"`
+
+	// DryRun, when true, evaluates the onCreate/onUpdate/onDelete queries in
+	// Kubernetes dry-run mode without persisting any changes, and skips the
+	// operator's own mutations (finalizers and owner references). It lets you
+	// preview what the operator would do. Defaults to false.
+	// +kubebuilder:default=false
+	// +optional
+	DryRun bool `json:"dryRun,omitempty"`
 }
 
 // DynamicOperatorStatus defines the observed state of DynamicOperator

--- a/operator/config/crd/bases/cyphernetes-operator.cyphernet.es_dynamicoperators.yaml
+++ b/operator/config/crd/bases/cyphernetes-operator.cyphernet.es_dynamicoperators.yaml
@@ -49,6 +49,14 @@ spec:
           spec:
             description: DynamicOperatorSpec defines the desired state of DynamicOperator
             properties:
+              dryRun:
+                default: false
+                description: |-
+                  DryRun, when true, evaluates the onCreate/onUpdate/onDelete queries in
+                  Kubernetes dry-run mode without persisting any changes, and skips the
+                  operator's own mutations (finalizers and owner references). It lets you
+                  preview what the operator would do. Defaults to false.
+                type: boolean
               namespace:
                 description: Namespace specifies the namespace to watch. If empty,
                   it watches all namespaces

--- a/operator/internal/controller/dynamicoperator_controller.go
+++ b/operator/internal/controller/dynamicoperator_controller.go
@@ -339,9 +339,17 @@ func (r *DynamicOperatorReconciler) handleCreate(ctx context.Context, dynamicOpe
 	log.Log.Info("handleCreate called", "resource", getName(obj), "namespace", namespace)
 
 	if dynamicOperator.Spec.OnCreate != "" {
-		err := r.executeCyphernetesQuery(dynamicOperator.Spec.OnCreate, obj, namespace)
+		err := r.executeCyphernetesQuery(dynamicOperator, dynamicOperator.Spec.OnCreate, obj, namespace)
 		if err != nil {
 			log.Log.Error(err, "Failed to execute onCreate query")
+			return
+		}
+
+		// In dry-run mode we must not mutate the cluster, so skip adding the
+		// finalizer to the watched resource. onDelete is still previewed via the
+		// regular delete event (see handleDelete).
+		if dynamicOperator.Spec.DryRun {
+			log.Log.Info("Dry-run mode: skipping finalizer addition", "resource", getName(obj))
 			return
 		}
 
@@ -379,7 +387,7 @@ func (r *DynamicOperatorReconciler) addFinalizer(ctx context.Context, dynamicOpe
 
 func (r *DynamicOperatorReconciler) handleUpdate(ctx context.Context, dynamicOperator *operatorv1.DynamicOperator, obj interface{}, namespace string) {
 	if dynamicOperator.Spec.OnUpdate != "" {
-		err := r.executeCyphernetesQuery(dynamicOperator.Spec.OnUpdate, obj, namespace)
+		err := r.executeCyphernetesQuery(dynamicOperator, dynamicOperator.Spec.OnUpdate, obj, namespace)
 		if err != nil {
 			log.Log.Error(err, "Failed to execute onUpdate query")
 		}
@@ -397,12 +405,27 @@ func (r *DynamicOperatorReconciler) handleDelete(ctx context.Context, dynamicOpe
 
 	log.Log.Info("Object details", "name", u.GetName(), "namespace", u.GetNamespace(), "finalizers", u.GetFinalizers())
 
+	// In dry-run mode we never added a finalizer, so the resource is deleted
+	// immediately and this handler runs after the fact. Preview the onDelete
+	// query (in dry-run) without requiring or removing a finalizer.
+	if dynamicOperator.Spec.DryRun {
+		if dynamicOperator.Spec.OnDelete != "" {
+			log.Log.Info("Dry-run mode: previewing onDelete query", "resource", u.GetName())
+			if err := r.executeCyphernetesQuery(dynamicOperator, dynamicOperator.Spec.OnDelete, obj, namespace); err != nil {
+				log.Log.Error(err, "Failed to preview onDelete query")
+			}
+		} else {
+			log.Log.Info("No onDelete query specified", "resource", u.GetName())
+		}
+		return
+	}
+
 	// Check if the object has our finalizer
 	if containsString(u.GetFinalizers(), finalizerName) {
 		log.Log.Info("Finalizer found, executing onDelete query", "resource", u.GetName())
 		// Execute onDelete query if specified
 		if dynamicOperator.Spec.OnDelete != "" {
-			err := r.executeCyphernetesQuery(dynamicOperator.Spec.OnDelete, obj, namespace)
+			err := r.executeCyphernetesQuery(dynamicOperator, dynamicOperator.Spec.OnDelete, obj, namespace)
 			if err != nil {
 				log.Log.Error(err, "Failed to execute onDelete query")
 				// Continue with finalizer removal even if the query fails
@@ -469,7 +492,7 @@ func getName(obj interface{}) string {
 	return unstructuredObj.GetName()
 }
 
-func (r *DynamicOperatorReconciler) executeCyphernetesQuery(query string, obj interface{}, namespace string) error {
+func (r *DynamicOperatorReconciler) executeCyphernetesQuery(dynamicOperator *operatorv1.DynamicOperator, query string, obj interface{}, namespace string) error {
 	// Convert the object to a map for easier JSON path access
 	objMap := make(map[string]interface{})
 	objJSON, err := json.Marshal(obj)
@@ -493,7 +516,7 @@ func (r *DynamicOperatorReconciler) executeCyphernetesQuery(query string, obj in
 
 	// Execute each statement
 	for _, statement := range statements {
-		err := r.executeStatement(statement, objMap, namespace)
+		err := r.executeStatement(dynamicOperator, statement, objMap, namespace)
 		if err != nil {
 			return fmt.Errorf("error executing statement: %v", err)
 		}
@@ -505,7 +528,7 @@ func (r *DynamicOperatorReconciler) executeCyphernetesQuery(query string, obj in
 	return nil
 }
 
-func (r *DynamicOperatorReconciler) executeStatement(statement string, objMap map[string]interface{}, namespace string) error {
+func (r *DynamicOperatorReconciler) executeStatement(dynamicOperator *operatorv1.DynamicOperator, statement string, objMap map[string]interface{}, namespace string) error {
 	// Regular expression to find all {{$.path.to.property}} patterns
 	re := regexp.MustCompile(`\{\{\$(.[^}]+)\}\}`)
 
@@ -539,8 +562,10 @@ func (r *DynamicOperatorReconciler) executeStatement(statement string, objMap ma
 		return err
 	}
 
-	// Execute the sanitized statement
-	result, err := r.QueryExecutor.Execute(ast, namespace)
+	// Execute the sanitized statement. Dry-run is applied per call so a single
+	// shared executor safely serves both dry-run and real operators, even when
+	// their informer goroutines fire concurrently.
+	result, err := r.QueryExecutor.Execute(ast, namespace, core.WithDryRun(dynamicOperator.Spec.DryRun))
 
 	if err != nil {
 		// Check if the error is due to "already exists"
@@ -551,8 +576,10 @@ func (r *DynamicOperatorReconciler) executeStatement(statement string, objMap ma
 		}
 	}
 
-	// Check if we need to add owner references to created resources
-	if createClause := findCreateClause(ast); createClause != nil {
+	// Check if we need to add owner references to created resources. In dry-run
+	// mode nothing was actually created, so there is no resource to fetch or own;
+	// skip owner-reference handling entirely to keep the cluster untouched.
+	if createClause := findCreateClause(ast); createClause != nil && !dynamicOperator.Spec.DryRun {
 		var nodesToAddOwnerRef []*core.NodePattern
 		var matchCreateNode *core.NodePattern
 

--- a/operator/internal/controller/dynamicoperator_controller_test.go
+++ b/operator/internal/controller/dynamicoperator_controller_test.go
@@ -86,15 +86,15 @@ func (m *MockProvider) GetK8sResources(kind, fieldSelector, labelSelector, names
 	return []map[string]interface{}{}, nil
 }
 
-func (m *MockProvider) DeleteK8sResources(kind, name, namespace string) error {
+func (m *MockProvider) DeleteK8sResources(kind, name, namespace string, dryRun bool) error {
 	return nil
 }
 
-func (m *MockProvider) CreateK8sResource(kind, name, namespace string, body interface{}) error {
+func (m *MockProvider) CreateK8sResource(kind, name, namespace string, body interface{}, dryRun bool) error {
 	return nil
 }
 
-func (m *MockProvider) PatchK8sResource(group, version, resource string, patch []byte) error {
+func (m *MockProvider) PatchK8sResource(group, version, resource string, patch []byte, dryRun bool) error {
 	return nil
 }
 
@@ -104,10 +104,6 @@ func (m *MockProvider) CreateProviderForContext(context string) (provider.Provid
 
 func (m *MockProvider) GetDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	return m.clientset.Discovery(), nil
-}
-
-func (m *MockProvider) ToggleDryRun() {
-	// do nothing
 }
 
 var _ = Describe("DynamicOperator Controller", func() {

--- a/operator/internal/controller/dynamicoperator_dryrun_test.go
+++ b/operator/internal/controller/dynamicoperator_dryrun_test.go
@@ -1,0 +1,310 @@
+package controller
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	operatorv1 "github.com/avitaltamir/cyphernetes/operator/api/v1"
+	core "github.com/avitaltamir/cyphernetes/pkg/core"
+	"github.com/avitaltamir/cyphernetes/pkg/provider/apiserver"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// newMockExecutor builds a QueryExecutor backed by the test MockProvider. It
+// does not touch the cluster, so it is safe to use in unit tests.
+func newMockExecutor() *core.QueryExecutor {
+	exec, err := core.NewQueryExecutor(NewMockProvider(nil, nil))
+	if err != nil {
+		panic(err)
+	}
+	return exec
+}
+
+// ConfigMaps are used as the watched resource in these tests because, unlike
+// Pods, they are not mutated by the kubelet after creation. That keeps the
+// resourceVersion stable so the controller's finalizer update does not race a
+// concurrent controller-driven update on a live cluster.
+var configMapsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+func newTestConfigMap(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"data": map[string]interface{}{
+			"key": "value",
+		},
+	}}
+}
+
+var _ = Describe("DynamicOperator dry-run mode", func() {
+	const namespace = "default"
+
+	var (
+		dynamicClient dynamic.Interface
+		clientset     kubernetes.Interface
+		reconciler    *DynamicOperatorReconciler
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		clientset, err = kubernetes.NewForConfig(testEnv.Config)
+		Expect(err).NotTo(HaveOccurred())
+		dynamicClient, err = dynamic.NewForConfig(testEnv.Config)
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciler = &DynamicOperatorReconciler{
+			Client:         k8sClient,
+			Scheme:         k8sClient.Scheme(),
+			Clientset:      clientset,
+			DynamicClient:  dynamicClient,
+			QueryExecutor:  newMockExecutor(),
+			lastExecution:  make(map[string]time.Time),
+			activeWatchers: make(map[string]context.CancelFunc),
+		}
+	})
+
+	deleteConfigMap := func(name string) {
+		_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(
+			ctx, name, metav1.DeleteOptions{GracePeriodSeconds: ptrInt64(0)})
+	}
+
+	Context("when handling create for a dryRun=true operator", func() {
+		It("does not add the operator finalizer to the watched resource", func() {
+			const cmName = "dryrun-create-cm"
+			deleteConfigMap(cmName)
+
+			created, err := dynamicClient.Resource(configMapsGVR).Namespace(namespace).Create(
+				ctx, newTestConfigMap(cmName, namespace), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer deleteConfigMap(cmName)
+
+			op := &operatorv1.DynamicOperator{
+				Spec: operatorv1.DynamicOperatorSpec{
+					ResourceKind: "ConfigMap",
+					Namespace:    namespace,
+					OnCreate:     "MATCH (n:ConfigMap) RETURN n",
+					DryRun:       true,
+				},
+			}
+
+			reconciler.handleCreate(ctx, op, created, namespace)
+
+			// Give any (erroneous) finalizer write a chance to land before asserting.
+			Consistently(func() []string {
+				fetched, getErr := dynamicClient.Resource(configMapsGVR).Namespace(namespace).Get(ctx, cmName, metav1.GetOptions{})
+				if getErr != nil {
+					return nil
+				}
+				return fetched.GetFinalizers()
+			}, time.Second*2, time.Millisecond*250).ShouldNot(ContainElement(finalizerName),
+				"dry-run mode must not mutate the watched resource")
+		})
+	})
+
+	Context("when handling create for a dryRun=false operator", func() {
+		It("adds the operator finalizer to the watched resource", func() {
+			const cmName = "realrun-create-cm"
+			deleteConfigMap(cmName)
+
+			created, err := dynamicClient.Resource(configMapsGVR).Namespace(namespace).Create(
+				ctx, newTestConfigMap(cmName, namespace), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				// Remove the finalizer so the ConfigMap can actually be deleted.
+				latest, getErr := dynamicClient.Resource(configMapsGVR).Namespace(namespace).Get(ctx, cmName, metav1.GetOptions{})
+				if getErr == nil {
+					latest.SetFinalizers(removeString(latest.GetFinalizers(), finalizerName))
+					_, _ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Update(ctx, latest, metav1.UpdateOptions{})
+				}
+				deleteConfigMap(cmName)
+			}()
+
+			op := &operatorv1.DynamicOperator{
+				Spec: operatorv1.DynamicOperatorSpec{
+					ResourceKind: "ConfigMap",
+					Namespace:    namespace,
+					OnCreate:     "MATCH (n:ConfigMap) RETURN n",
+					DryRun:       false,
+				},
+			}
+
+			reconciler.handleCreate(ctx, op, created, namespace)
+
+			Eventually(func() []string {
+				fetched, getErr := dynamicClient.Resource(configMapsGVR).Namespace(namespace).Get(ctx, cmName, metav1.GetOptions{})
+				if getErr != nil {
+					return nil
+				}
+				return fetched.GetFinalizers()
+			}, time.Second*5, time.Millisecond*250).Should(ContainElement(finalizerName),
+				"non-dry-run mode should add the operator finalizer")
+		})
+	})
+
+	Context("when handling delete for a dryRun=true operator", func() {
+		It("previews onDelete without requiring or removing a finalizer", func() {
+			const cmName = "dryrun-delete-cm"
+			cm := newTestConfigMap(cmName, namespace)
+			// Note: no finalizer is set, mirroring dry-run create behavior.
+
+			op := &operatorv1.DynamicOperator{
+				Spec: operatorv1.DynamicOperatorSpec{
+					ResourceKind: "ConfigMap",
+					Namespace:    namespace,
+					OnDelete:     "MATCH (n:ConfigMap) RETURN n",
+					DryRun:       true,
+				},
+			}
+
+			// Should not panic or error even though the resource has no finalizer
+			// and does not exist in the cluster.
+			Expect(func() {
+				reconciler.handleDelete(ctx, op, cm, namespace)
+			}).NotTo(Panic())
+		})
+	})
+})
+
+func ptrInt64(v int64) *int64 { return &v }
+
+// This end-to-end spec proves the actual mutation-suppression behavior against a
+// real cluster: a CREATE query run with core.WithDryRun(true) must not persist
+// anything, while the same query without it must. A single shared executor is
+// used for both, demonstrating that dry-run is a per-call property.
+var _ = Describe("DynamicOperator dry-run query execution (end-to-end)", func() {
+	const namespace = "default"
+
+	var (
+		dynamicClient dynamic.Interface
+		clientset     kubernetes.Interface
+		executor      *core.QueryExecutor
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		clientset, err = kubernetes.NewForConfig(testEnv.Config)
+		Expect(err).NotTo(HaveOccurred())
+		dynamicClient, err = dynamic.NewForConfig(testEnv.Config)
+		Expect(err).NotTo(HaveOccurred())
+
+		provider, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
+			Clientset:     clientset,
+			DynamicClient: dynamicClient,
+			QuietMode:     true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		executor, err = core.NewQueryExecutor(provider)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	createQuery := func(name string) string {
+		return `CREATE (c:ConfigMap {"metadata": {"name": "` + name + `", "namespace": "` + namespace + `"}, "data": {"foo": "bar"}})`
+	}
+
+	configMapExists := func(name string) bool {
+		_, err := dynamicClient.Resource(configMapsGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		Expect(err).NotTo(HaveOccurred())
+		return true
+	}
+
+	It("does not persist a CREATE when run with WithDryRun(true)", func() {
+		const cmName = "e2e-dryrun-created-cm"
+		_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
+
+		ast, err := core.ParseQuery(createQuery(cmName))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = executor.Execute(ast, namespace, core.WithDryRun(true))
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(func() bool { return configMapExists(cmName) },
+			time.Second*2, time.Millisecond*250).Should(BeFalse(),
+			"dry-run execution must not persist the created ConfigMap")
+	})
+
+	It("persists a CREATE when run without dry-run", func() {
+		const cmName = "e2e-real-created-cm"
+		_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
+		defer func() {
+			_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
+		}()
+
+		ast, err := core.ParseQuery(createQuery(cmName))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = executor.Execute(ast, namespace, core.WithDryRun(false))
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool { return configMapExists(cmName) },
+			time.Second*5, time.Millisecond*250).Should(BeTrue(),
+			"a non-dry-run execution should persist the created ConfigMap")
+	})
+
+	It("isolates dry-run and real executions running concurrently on one executor", func() {
+		// The scenario per-call dry-run must handle: one operator in dry-run and
+		// one running for real, both firing at the same time through the single
+		// shared executor. The dry-run side must never persist a mutation, even
+		// while the real side concurrently does.
+		const dryCM = "concurrent-dryrun-cm"
+		const realCM = "concurrent-real-cm"
+		_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, dryCM, metav1.DeleteOptions{})
+		_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, realCM, metav1.DeleteOptions{})
+		defer func() {
+			_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, dryCM, metav1.DeleteOptions{})
+			_ = dynamicClient.Resource(configMapsGVR).Namespace(namespace).Delete(ctx, realCM, metav1.DeleteOptions{})
+		}()
+
+		const iterations = 15
+		var wg sync.WaitGroup
+		for i := 0; i < iterations; i++ {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				// Parse per-goroutine; ASTs are not shared across executions.
+				ast, parseErr := core.ParseQuery(createQuery(dryCM))
+				Expect(parseErr).NotTo(HaveOccurred())
+				_, _ = executor.Execute(ast, namespace, core.WithDryRun(true))
+			}()
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				ast, parseErr := core.ParseQuery(createQuery(realCM))
+				Expect(parseErr).NotTo(HaveOccurred())
+				// "already exists" after the first create is expected and fine.
+				_, _ = executor.Execute(ast, namespace, core.WithDryRun(false))
+			}()
+		}
+		wg.Wait()
+
+		// The real execution's ConfigMap must exist; the dry-run execution's must
+		// never have been persisted despite the concurrent real mutations.
+		Expect(configMapExists(realCM)).To(BeTrue(),
+			"the non-dry-run execution should have persisted its ConfigMap")
+		Consistently(func() bool { return configMapExists(dryCM) },
+			time.Second*2, time.Millisecond*250).Should(BeFalse(),
+			"the dry-run execution must never persist, even under concurrency with a real execution")
+	})
+})

--- a/operator/test/e2e/e2e_test.go
+++ b/operator/test/e2e/e2e_test.go
@@ -71,15 +71,15 @@ func (m *MockProvider) GetK8sResources(kind, fieldSelector, labelSelector, names
 	return nil, nil
 }
 
-func (m *MockProvider) DeleteK8sResources(kind, name, namespace string) error {
+func (m *MockProvider) DeleteK8sResources(kind, name, namespace string, dryRun bool) error {
 	return nil
 }
 
-func (m *MockProvider) CreateK8sResource(kind, name, namespace string, body interface{}) error {
+func (m *MockProvider) CreateK8sResource(kind, name, namespace string, body interface{}, dryRun bool) error {
 	return nil
 }
 
-func (m *MockProvider) PatchK8sResource(group, version, resource string, patch []byte) error {
+func (m *MockProvider) PatchK8sResource(group, version, resource string, patch []byte, dryRun bool) error {
 	return nil
 }
 
@@ -111,10 +111,6 @@ func (m *MockProvider) GetOpenAPIResourceSpecs() (map[string][]string, error) {
 
 func (m *MockProvider) CreateProviderForContext(context string) (provider.Provider, error) {
 	return m, nil
-}
-
-func (m *MockProvider) ToggleDryRun() {
-	// do nothing
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/core/dryrun_test.go
+++ b/pkg/core/dryrun_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/avitaltamir/cyphernetes/pkg/provider"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// recordingProvider captures the dryRun flag passed to each mutating call so we
+// can assert that Execute threads WithDryRun all the way down to the provider.
+type recordingProvider struct {
+	mu           sync.Mutex
+	createDryRun []bool
+}
+
+func (p *recordingProvider) GetK8sResources(kind, fieldSelector, labelSelector, namespace string) (interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+func (p *recordingProvider) DeleteK8sResources(kind, name, namespace string, dryRun bool) error {
+	return nil
+}
+
+func (p *recordingProvider) CreateK8sResource(kind, name, namespace string, body interface{}, dryRun bool) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.createDryRun = append(p.createDryRun, dryRun)
+	return nil
+}
+
+func (p *recordingProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte, dryRun bool) error {
+	return nil
+}
+
+func (p *recordingProvider) FindGVR(kind string) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}, nil
+}
+
+func (p *recordingProvider) GetOpenAPIResourceSpecs() (map[string][]string, error) {
+	return map[string][]string{}, nil
+}
+
+func (p *recordingProvider) CreateProviderForContext(context string) (provider.Provider, error) {
+	return p, nil
+}
+
+func (p *recordingProvider) lastCreateDryRun() (bool, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.createDryRun) == 0 {
+		return false, false
+	}
+	return p.createDryRun[len(p.createDryRun)-1], true
+}
+
+// TestExecuteThreadsDryRunToProvider proves dry-run is a per-call property: the
+// value passed via WithDryRun reaches the provider's mutating call, and the same
+// executor yields different results on consecutive calls.
+func TestExecuteThreadsDryRunToProvider(t *testing.T) {
+	const createQuery = `CREATE (c:ConfigMap {"metadata": {"name": "x", "namespace": "default"}, "data": {"foo": "bar"}})`
+
+	cases := []struct {
+		name string
+		opts []ExecuteOption
+		want bool
+	}{
+		{name: "WithDryRun(true)", opts: []ExecuteOption{WithDryRun(true)}, want: true},
+		{name: "WithDryRun(false)", opts: []ExecuteOption{WithDryRun(false)}, want: false},
+		{name: "no option defaults to false", opts: nil, want: false},
+	}
+
+	rec := &recordingProvider{}
+	executor, err := NewQueryExecutor(rec)
+	if err != nil {
+		t.Fatalf("NewQueryExecutor: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ast, err := ParseQuery(createQuery)
+			if err != nil {
+				t.Fatalf("ParseQuery: %v", err)
+			}
+			if _, err := executor.Execute(ast, "default", tc.opts...); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			got, ok := rec.lastCreateDryRun()
+			if !ok {
+				t.Fatal("provider CreateK8sResource was never called")
+			}
+			if got != tc.want {
+				t.Fatalf("provider received dryRun=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/core/e2e/input_validation_test.go
+++ b/pkg/core/e2e/input_validation_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Input Validation", func() {
 	Context("PatchK8sResource", func() {
 		It("should handle invalid inputs correctly", func() {
 			By("Testing with empty kind")
-			err = provider.PatchK8sResource("", "name", "default", []byte(`[{"op": "add", "path": "/metadata/labels/test", "value": "test"}]`))
+			err = provider.PatchK8sResource("", "name", "default", []byte(`[{"op": "add", "path": "/metadata/labels/test", "value": "test"}]`), false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid resource kind"))
 
@@ -100,25 +100,25 @@ var _ = Describe("Input Validation", func() {
 					},
 				},
 			}
-			err = provider.CreateK8sResource("pod", "test-patch-pod", "default", testPod)
+			err = provider.CreateK8sResource("pod", "test-patch-pod", "default", testPod, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				_ = provider.DeleteK8sResources("pod", "test-patch-pod", "default")
+				_ = provider.DeleteK8sResources("pod", "test-patch-pod", "default", false)
 			})
 
 			By("Testing with invalid JSON patch")
-			err = provider.PatchK8sResource("pod", "test-patch-pod", "default", []byte(`invalid json`))
+			err = provider.PatchK8sResource("pod", "test-patch-pod", "default", []byte(`invalid json`), false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid"))
 
 			By("Testing with invalid patch operation")
-			err = provider.PatchK8sResource("pod", "test-patch-pod", "default", []byte(`[{"op": "invalid", "path": "/metadata/labels/test", "value": "test"}]`))
+			err = provider.PatchK8sResource("pod", "test-patch-pod", "default", []byte(`[{"op": "invalid", "path": "/metadata/labels/test", "value": "test"}]`), false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("the server rejected our request"))
 
 			By("Testing with non-existent resource")
-			err = provider.PatchK8sResource("pod", "non-existent-pod", "default", []byte(`[{"op": "add", "path": "/metadata/labels/test", "value": "test"}]`))
+			err = provider.PatchK8sResource("pod", "non-existent-pod", "default", []byte(`[{"op": "add", "path": "/metadata/labels/test", "value": "test"}]`), false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 		})

--- a/pkg/core/engine.go
+++ b/pkg/core/engine.go
@@ -65,12 +65,35 @@ func NewQueryExecutor(p provider.Provider) (*QueryExecutor, error) {
 	}, nil
 }
 
-func (q *QueryExecutor) Execute(ast *Expression, namespace string) (QueryResult, error) {
+// ExecuteOption configures a single query execution.
+type ExecuteOption func(*executeOptions)
+
+type executeOptions struct {
+	dryRun bool
+}
+
+// WithDryRun runs the execution's mutations (CREATE/SET/DELETE) in Kubernetes
+// dry-run mode when dryRun is true: changes are validated by the API server but
+// not persisted. Dry-run is scoped to this single Execute call, so the same
+// executor can serve dry-run and real queries concurrently.
+func WithDryRun(dryRun bool) ExecuteOption {
+	return func(o *executeOptions) { o.dryRun = dryRun }
+}
+
+func resolveExecuteOptions(opts []ExecuteOption) executeOptions {
+	var o executeOptions
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}
+
+func (q *QueryExecutor) Execute(ast *Expression, namespace string, opts ...ExecuteOption) (QueryResult, error) {
 	if ast == nil {
 		return QueryResult{}, fmt.Errorf("empty query: ast cannot be nil")
 	}
 	if len(ast.Contexts) > 0 {
-		return ExecuteMultiContextQuery(ast, namespace)
+		return ExecuteMultiContextQuery(ast, namespace, opts...)
 	}
 
 	// First, check for kindless nodes and rewrite the query if needed
@@ -82,7 +105,7 @@ func (q *QueryExecutor) Execute(ast *Expression, namespace string) (QueryResult,
 		ast = rewrittenAst
 	}
 
-	result, err := q.ExecuteSingleQuery(ast, namespace)
+	result, err := q.ExecuteSingleQuery(ast, namespace, opts...)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/core/engine_test.go
+++ b/pkg/core/engine_test.go
@@ -17,15 +17,15 @@ func (m *MockProvider) GetK8sResources(kind string, fieldSelector string, labelS
 	return []map[string]interface{}{}, nil
 }
 
-func (m *MockProvider) DeleteK8sResources(kind string, name string, namespace string) error {
+func (m *MockProvider) DeleteK8sResources(kind string, name string, namespace string, dryRun bool) error {
 	return nil
 }
 
-func (m *MockProvider) CreateK8sResource(kind string, name string, namespace string, spec interface{}) error {
+func (m *MockProvider) CreateK8sResource(kind string, name string, namespace string, spec interface{}, dryRun bool) error {
 	return nil
 }
 
-func (m *MockProvider) PatchK8sResource(kind string, name string, namespace string, patchJSON []byte) error {
+func (m *MockProvider) PatchK8sResource(kind string, name string, namespace string, patchJSON []byte, dryRun bool) error {
 	return nil
 }
 
@@ -39,10 +39,6 @@ func (m *MockProvider) GetOpenAPIResourceSpecs() (map[string][]string, error) {
 
 func (m *MockProvider) CreateProviderForContext(context string) (provider.Provider, error) {
 	return &MockProvider{}, nil
-}
-
-func (m *MockProvider) ToggleDryRun() {
-	// do nothing
 }
 
 func TestJsonPath(t *testing.T) {

--- a/pkg/core/execute.go
+++ b/pkg/core/execute.go
@@ -10,8 +10,10 @@ import (
 	"github.com/AvitalTamir/jsonpath"
 )
 
-func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string) (QueryResult, error) {
-	return q.executeSingleQuery(ast, namespace, newExecutionState())
+func (q *QueryExecutor) ExecuteSingleQuery(ast *Expression, namespace string, opts ...ExecuteOption) (QueryResult, error) {
+	state := newExecutionState()
+	state.dryRun = resolveExecuteOptions(opts).dryRun
+	return q.executeSingleQuery(ast, namespace, state)
 }
 
 func (q *QueryExecutor) executeSingleQuery(ast *Expression, namespace string, state *executionState) (QueryResult, error) {
@@ -115,7 +117,7 @@ func (q *QueryExecutor) executeSingleQuery(ast *Expression, namespace string, st
 					if err != nil {
 						return *results, fmt.Errorf("error resolving resource kind %s: %v", nodeKind, err)
 					}
-					err = q.provider.DeleteK8sResources(providerKind, name, namespace)
+					err = q.provider.DeleteK8sResources(providerKind, name, namespace, state.dryRun)
 					if err != nil {
 						return *results, fmt.Errorf("error deleting resource %s/%s: %v", nodeKind, name, err)
 					}
@@ -349,6 +351,7 @@ func (q *QueryExecutor) executeSingleQuery(ast *Expression, namespace string, st
 						name,
 						state.namespace,
 						resourceTemplate,
+						state.dryRun,
 					)
 					if err != nil {
 						return *results, fmt.Errorf("error creating resource >> %v", err)
@@ -391,6 +394,7 @@ func (q *QueryExecutor) executeSingleQuery(ast *Expression, namespace string, st
 						name,
 						state.namespace,
 						resourceTemplate,
+						state.dryRun,
 					)
 					if err != nil {
 						return *results, fmt.Errorf("error creating resource >> %v", err)

--- a/pkg/core/execution_hardening_test.go
+++ b/pkg/core/execution_hardening_test.go
@@ -63,21 +63,21 @@ func (p *hardeningProvider) GetK8sResources(kind, fieldSelector, labelSelector, 
 	return out, nil
 }
 
-func (p *hardeningProvider) DeleteK8sResources(kind, name, namespace string) error {
+func (p *hardeningProvider) DeleteK8sResources(kind, name, namespace string, dryRun bool) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.deletes = append(p.deletes, fmt.Sprintf("%s/%s/%s", kind, namespace, name))
 	return nil
 }
 
-func (p *hardeningProvider) CreateK8sResource(kind, name, namespace string, body interface{}) error {
+func (p *hardeningProvider) CreateK8sResource(kind, name, namespace string, body interface{}, dryRun bool) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.creates = append(p.creates, fmt.Sprintf("%s/%s/%s", kind, namespace, name))
 	return nil
 }
 
-func (p *hardeningProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte) error {
+func (p *hardeningProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte, dryRun bool) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.patches = append(p.patches, fmt.Sprintf("%s/%s/%s:%s", kind, namespace, name, string(patchJSON)))
@@ -114,8 +114,6 @@ func (p *hardeningProvider) GetOpenAPIResourceSpecs() (map[string][]string, erro
 func (p *hardeningProvider) CreateProviderForContext(context string) (provider.Provider, error) {
 	return p, nil
 }
-
-func (p *hardeningProvider) ToggleDryRun() {}
 
 func TestExecutionUsesSelectorAwareCacheKeys(t *testing.T) {
 	executor, _ := NewQueryExecutor(newHardeningProvider())

--- a/pkg/core/helper_hardening_test.go
+++ b/pkg/core/helper_hardening_test.go
@@ -215,7 +215,7 @@ func TestPatchJsonPathAndSetHelpers(t *testing.T) {
 	provider := newHardeningProvider()
 	executor, _ := NewQueryExecutor(provider)
 	patchJSON, _ := json.Marshal([]map[string]interface{}{{"op": "add", "path": "/metadata/labels/team", "value": "core"}})
-	if err := executor.PatchK8sResource(resource, patchJSON); err != nil {
+	if err := executor.PatchK8sResource(resource, patchJSON, false); err != nil {
 		t.Fatal(err)
 	}
 	if len(provider.patches) != 1 || !strings.Contains(provider.patches[0], "/metadata/labels/team") {

--- a/pkg/core/multicontext.go
+++ b/pkg/core/multicontext.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func ExecuteMultiContextQuery(ast *Expression, namespace string) (QueryResult, error) {
+func ExecuteMultiContextQuery(ast *Expression, namespace string, opts ...ExecuteOption) (QueryResult, error) {
 	if len(ast.Contexts) == 0 {
 		return QueryResult{}, fmt.Errorf("no contexts provided for multi-context query")
 	}
@@ -30,7 +30,7 @@ func ExecuteMultiContextQuery(ast *Expression, namespace string) (QueryResult, e
 		modifiedAst := prefixVariables(ast, context)
 
 		// Use ExecuteSingleQuery instead of Execute
-		result, err := executor.ExecuteSingleQuery(modifiedAst, namespace)
+		result, err := executor.ExecuteSingleQuery(modifiedAst, namespace, opts...)
 		if err != nil {
 			return combinedResults, fmt.Errorf("error executing query in context %s: %v", context, err)
 		}

--- a/pkg/core/set.go
+++ b/pkg/core/set.go
@@ -218,7 +218,7 @@ func updateResultMap(resource map[string]interface{}, path []string, value inter
 	current[path[len(path)-1]] = value
 }
 
-func (q *QueryExecutor) PatchK8sResource(resource map[string]interface{}, patchJSON []byte) error {
+func (q *QueryExecutor) PatchK8sResource(resource map[string]interface{}, patchJSON []byte, dryRun bool) error {
 	// Get the resource details
 	name := resource["metadata"].(map[string]interface{})["name"].(string)
 	namespace := ""
@@ -231,7 +231,7 @@ func (q *QueryExecutor) PatchK8sResource(resource map[string]interface{}, patchJ
 		return fmt.Errorf("error resolving resource kind %s: %v", kind, err)
 	}
 
-	return q.provider.PatchK8sResource(providerKind, name, namespace, patchJSON)
+	return q.provider.PatchK8sResource(providerKind, name, namespace, patchJSON, dryRun)
 }
 
 func (q *QueryExecutor) handleSetClause(c *SetClause, state *executionState) error {
@@ -315,7 +315,7 @@ func (q *QueryExecutor) handleSetClause(c *SetClause, state *executionState) err
 				if err != nil {
 					return fmt.Errorf("error resolving resource kind %s: %v", nodeKind, err)
 				}
-				err = q.provider.PatchK8sResource(providerKind, name, namespace, patchJSON)
+				err = q.provider.PatchK8sResource(providerKind, name, namespace, patchJSON, state.dryRun)
 				if err != nil {
 					return fmt.Errorf("error patching resource: %s", err)
 				}

--- a/pkg/core/state.go
+++ b/pkg/core/state.go
@@ -13,6 +13,7 @@ type executionState struct {
 	resultCache map[string]interface{}
 	matchNodes  []*NodePattern
 	namespace   string
+	dryRun      bool
 	graphNodes  map[string]bool
 	graphEdges  map[string]bool
 	hasPatterns bool

--- a/pkg/provider/apiserver/provider.go
+++ b/pkg/provider/apiserver/provider.go
@@ -33,7 +33,6 @@ type APIServerProviderConfig struct {
 	Clientset     kubernetes.Interface
 	DynamicClient dynamic.Interface
 	Kubeconfig    *rest.Config
-	DryRun        bool
 	QuietMode     bool
 }
 
@@ -46,7 +45,6 @@ type APIServerProvider struct {
 	requestChannel     chan *apiRequest
 	semaphore          chan struct{}
 	resourceMutex      sync.RWMutex
-	dryRun             bool
 	quietMode          bool
 	namespacedCache    map[string]bool
 	namespacedMutex    sync.RWMutex
@@ -125,16 +123,9 @@ func NewAPIServerProviderWithOptions(config *APIServerProviderConfig) (provider.
 		gvrCache:           make(map[string]schema.GroupVersionResource),
 		requestChannel:     make(chan *apiRequest),
 		semaphore:          make(chan struct{}, 1),
-		dryRun:             config.DryRun,
 		quietMode:          config.QuietMode,
 		namespacedCache:    make(map[string]bool),
 		knownResourceKinds: make([]string, 0),
-	}
-
-	if config.DryRun {
-		if !config.QuietMode {
-			fmt.Println("Provider initialized in dry-run mode")
-		}
 	}
 
 	// Start the request processor
@@ -349,7 +340,7 @@ func (p *APIServerProvider) FindGVR(kind string) (schema.GroupVersionResource, e
 }
 
 // Implement other Provider interface methods...
-func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string) error {
+func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string, dryRun bool) error {
 	p.resourceMutex.Lock()
 	defer p.resourceMutex.Unlock()
 
@@ -364,7 +355,7 @@ func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string) err
 	}
 
 	var deleteOpts metav1.DeleteOptions
-	if p.dryRun {
+	if dryRun {
 		deleteOpts.DryRun = []string{metav1.DryRunAll}
 	}
 
@@ -372,7 +363,7 @@ func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string) err
 	if namespace != "" && isNamespaced {
 		deleteErr = p.dynamicClient.Resource(gvr).Namespace(namespace).Delete(context.TODO(), name, deleteOpts)
 		if deleteErr == nil {
-			if p.dryRun {
+			if dryRun {
 				fmt.Printf("Dry run mode: would delete %s/%s\n", strings.ToLower(kind), name)
 			} else {
 				fmt.Printf("Deleted %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
@@ -390,7 +381,7 @@ func (p *APIServerProvider) DeleteK8sResources(kind, name, namespace string) err
 	return deleteErr
 }
 
-func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body interface{}) error {
+func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body interface{}, dryRun bool) error {
 	p.resourceMutex.Lock()
 	defer p.resourceMutex.Unlock()
 
@@ -416,7 +407,7 @@ func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body
 	metadata["name"] = name
 
 	createOpts := metav1.CreateOptions{}
-	if p.dryRun {
+	if dryRun {
 		createOpts.DryRun = []string{metav1.DryRunAll}
 	}
 
@@ -424,7 +415,7 @@ func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body
 		metadata["namespace"] = namespace
 		_, err = p.dynamicClient.Resource(gvr).Namespace(namespace).Create(context.TODO(), unstructuredObj, createOpts)
 		if err == nil {
-			if p.dryRun {
+			if dryRun {
 				fmt.Printf("\nDry run mode: would create %s/%s", strings.ToLower(kind), name)
 			} else {
 				fmt.Printf("\nCreated %s/%s in namespace %s", strings.ToLower(kind), name, namespace)
@@ -442,7 +433,7 @@ func (p *APIServerProvider) CreateK8sResource(kind, name, namespace string, body
 	return err
 }
 
-func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte) error {
+func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patchJSON []byte, dryRun bool) error {
 	gvr, err := p.findGVRForResourceOperation(kind)
 	if err != nil {
 		return err
@@ -457,7 +448,7 @@ func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patch
 
 	// Create patch options with dry run if needed
 	patchOpts := metav1.PatchOptions{}
-	if p.dryRun {
+	if dryRun {
 		patchOpts.DryRun = []string{metav1.DryRunAll}
 	}
 
@@ -582,7 +573,7 @@ func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patch
 						return fmt.Errorf("error applying container merge patch: %v", err)
 					}
 
-					if p.dryRun {
+					if dryRun {
 						fmt.Printf("Dry run mode: would patch %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
 					} else {
 						fmt.Printf("Patched %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
@@ -645,7 +636,7 @@ func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patch
 					return fmt.Errorf("error applying merge patch: %v", err)
 				}
 
-				if p.dryRun {
+				if dryRun {
 					fmt.Printf("Dry run mode: would patch %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
 				} else {
 					fmt.Printf("Patched %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
@@ -776,7 +767,7 @@ func (p *APIServerProvider) PatchK8sResource(kind, name, namespace string, patch
 		}
 	}
 
-	if p.dryRun {
+	if dryRun {
 		fmt.Printf("Dry run mode: would patch %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
 	} else {
 		fmt.Printf("Patched %s/%s in namespace %s\n", strings.ToLower(kind), name, namespace)
@@ -1172,7 +1163,6 @@ func (p *APIServerProvider) CreateProviderForContext(context string) (provider.P
 	return NewAPIServerProviderWithOptions(&APIServerProviderConfig{
 		Clientset:     clientset,
 		DynamicClient: dynamicClient,
-		DryRun:        p.dryRun,
 		QuietMode:     p.quietMode,
 	})
 }
@@ -1307,10 +1297,6 @@ func (p *APIServerProvider) isNamespacedResource(gvr schema.GroupVersionResource
 	}
 
 	return false, fmt.Errorf("resource %q not found", gvr.Resource)
-}
-
-func (p *APIServerProvider) ToggleDryRun() {
-	p.dryRun = !p.dryRun
 }
 
 func (p *APIServerProvider) GetKnownResourceKinds() []string {

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -7,18 +7,17 @@ import (
 // Provider defines the interface for different backend implementations
 type Provider interface {
 	// Resource Operations
-	// All operations support dry-run if the provider implementation supports it.
-	// Dry-run can be enabled through provider-specific configuration options.
+	// The mutating operations take a dryRun flag: when true the change is sent
+	// to the backend in dry-run mode (validated but not persisted). Dry-run is a
+	// per-call property, so the same provider can serve dry-run and real calls
+	// concurrently.
 	GetK8sResources(kind, fieldSelector, labelSelector, namespace string) (interface{}, error)
-	DeleteK8sResources(kind, name, namespace string) error
-	CreateK8sResource(kind, name, namespace string, body interface{}) error
-	PatchK8sResource(kind, name, namespace string, patchJSON []byte) error
+	DeleteK8sResources(kind, name, namespace string, dryRun bool) error
+	CreateK8sResource(kind, name, namespace string, body interface{}, dryRun bool) error
+	PatchK8sResource(kind, name, namespace string, patchJSON []byte, dryRun bool) error
 
 	// Schema Operations
 	FindGVR(kind string) (schema.GroupVersionResource, error)
 	GetOpenAPIResourceSpecs() (map[string][]string, error)
 	CreateProviderForContext(context string) (Provider, error)
-
-	// Configuration
-	ToggleDryRun()
 }


### PR DESCRIPTION
Closes #201.

## What

Adds a `dryRun` boolean to the `DynamicOperator` CRD (defaults to `false`). When `dryRun: true`, the operator still watches the target resource and evaluates the `onCreate`/`onUpdate`/`onDelete` queries, but:

- every mutation is sent to the Kubernetes API with `DryRunAll`, so **nothing is persisted**, and
- the operator skips its **own** side effects (it does not add finalizers or owner references).

This lets users preview what an operator would do (visible in the logs as `Dry run mode: would create/patch/delete ...`) before enabling it for real.

```yaml
apiVersion: cyphernetes-operator.cyphernet.es/v1
kind: DynamicOperator
metadata:
  name: ingress-activator-operator
  namespace: default
spec:
  resourceKind: deployments
  namespace: default
  dryRun: true # preview only; no changes are persisted
  onUpdate: |
    MATCH (d:Deployment {name: "{{$.metadata.name}}"})->(s:Service)->(i:Ingress)
    WHERE d.spec.replicas = 0
    SET i.spec.ingressClassName = "inactive";
```

## How — dry-run as a per-execution property

Dry-run is threaded through a single query execution, the same way `namespace` already is, rather than being held as provider state. This keeps the provider stateless and lets one shared executor serve dry-run and real queries concurrently with no shared flag to race.

- **`Provider` interface:** the mutating methods (`CreateK8sResource`/`PatchK8sResource`/`DeleteK8sResources`) take an explicit `dryRun bool`. The provider's `dryRun` field, the `DryRun` config option, and `ToggleDryRun()` are removed.
- **Engine:** `QueryExecutor.Execute` accepts a variadic `core.WithDryRun(bool)` option (non-breaking for the ~40 existing `Execute(ast, ns)` call sites), carried via `executionState` down to each provider mutation.
- **Operator:** passes `core.WithDryRun(spec.DryRun)` per reconcile. No second executor, no global toggle — a single shared executor is concurrency-safe by construction. The non-mutating guards (skip finalizer/owner-ref, preview `onDelete` without a finalizer) remain, keyed on `spec.DryRun`.
- **CLI/shell/API:** pass the flag at `Execute` time instead of configuring the provider or calling `ToggleDryRun`. User-facing behavior (`--dry-run`, `\dr`, the API `dryRun` field) is unchanged.

> Note: this replaces an earlier revision of this PR that used a second, dedicated dry-run executor. The per-call option is the cleaner long-term design — it removes the shared-state race at the root instead of working around it, and makes dry-run correct for every caller, not just the operator.

## Testing

All run against a live cluster (the suite uses `envtest` with `UseExistingCluster: true`), under `-race`:

- **`pkg/core` (no cluster):** `TestExecuteThreadsDryRunToProvider` proves `WithDryRun(true|false)` and the no-option default reach the provider's mutating call with the right value.
- **Operator behavior:** dry-run create does **not** add the finalizer; non-dry-run **does**; dry-run delete previews `onDelete` without a finalizer.
- **End-to-end:** a real `CREATE (c:ConfigMap …)` run with `WithDryRun(true)` persists nothing; the same query without it persists; and **concurrent** dry-run + real executions on **one** executor stay isolated (the dry-run side never persists while the real side does).

## Notes

- CRD manifest regenerated; the `controller-gen.kubebuilder.io/version` annotation is kept at the pinned v0.16.1, so the only manifest change is the new `dryRun` field. (controller-gen v0.16.1 does not build on Go 1.26, so the schema was generated with v0.19.0 and the annotation reverted.)
- `zz_generated.deepcopy.go` is unchanged — a plain `bool` field is value-copied by the existing `*out = *in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
