### PR TITLE
feat: add --context flag to choose kubeconfig context (#251)

### DIFF
--- a/cmd/cyphernetes/api.go
+++ b/cmd/cyphernetes/api.go
@@ -159,7 +159,9 @@ func handleConvertResourceName(c *gin.Context) {
 		return
 	}
 
-	p, err := apiserver.NewAPIServerProvider()
+	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
+		Context: core.KubeContext,
+	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not create API server provider"})
 		return
@@ -186,8 +188,11 @@ func handleGetContext(c *gin.Context) {
 		return
 	}
 
-	// Get current context
+	// Get current context, honoring an explicit --context override.
 	currentContext := config.CurrentContext
+	if core.KubeContext != "" {
+		currentContext = core.KubeContext
+	}
 	if currentContext == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "No current context set"})
 		return

--- a/cmd/cyphernetes/operator.go
+++ b/cmd/cyphernetes/operator.go
@@ -10,6 +10,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/avitaltamir/cyphernetes/pkg/core"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -23,11 +24,22 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 
 	corev1 "k8s.io/api/core/v1"
 )
+
+// buildOperatorKubeConfig loads the kubernetes rest.Config for operator commands,
+// honoring the KUBECONFIG env var and the global --context flag.
+func buildOperatorKubeConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	overrides := &clientcmd.ConfigOverrides{}
+	if core.KubeContext != "" {
+		overrides.CurrentContext = core.KubeContext
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
+}
 
 //go:embed manifests/*.yaml
 var manifestsFS embed.FS
@@ -69,8 +81,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 	fmt.Println("🚀 Deploying Cyphernetes operator...")
 
 	// Load kubernetes configuration
-	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := buildOperatorKubeConfig()
 	if err != nil {
 		fmt.Printf("Error building kubeconfig: %v\n", err)
 		os.Exit(1)
@@ -154,7 +165,7 @@ func applyManifest(manifest []byte) error {
 		return fmt.Errorf("error decoding manifest: %w", err)
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+	config, err := buildOperatorKubeConfig()
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig: %w", err)
 	}
@@ -280,8 +291,7 @@ func runRemove(cmd *cobra.Command, args []string) {
 	fmt.Println("🧹 Removing Cyphernetes operator...")
 
 	// Load kubernetes configuration
-	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := buildOperatorKubeConfig()
 	if err != nil {
 		fmt.Printf("Error building kubeconfig: %v\n", err)
 		os.Exit(1)
@@ -337,7 +347,7 @@ func deleteManifest(manifest []byte) error {
 		return fmt.Errorf("error decoding manifest: %w", err)
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+	config, err := buildOperatorKubeConfig()
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig: %w", err)
 	}

--- a/cmd/cyphernetes/query.go
+++ b/cmd/cyphernetes/query.go
@@ -40,6 +40,7 @@ var queryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		provider, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
 			QuietMode: true,
+			Context:   core.KubeContext,
 		})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error creating provider: ", err)
@@ -62,6 +63,7 @@ func runQuery(args []string, w io.Writer) {
 	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
 		DryRun:    DryRun,
 		QuietMode: true,
+		Context:   core.KubeContext,
 	})
 	if err != nil {
 		fmt.Fprintln(w, "Error creating provider: ", err)

--- a/cmd/cyphernetes/root.go
+++ b/cmd/cyphernetes/root.go
@@ -86,6 +86,7 @@ func init() {
 	// Add other flags
 	rootCmd.PersistentFlags().StringVarP(&core.Namespace, "namespace", "n", "default", "The namespace to query against")
 	rootCmd.PersistentFlags().BoolVarP(&core.AllNamespaces, "all-namespaces", "A", false, "Query all namespaces")
+	rootCmd.PersistentFlags().StringVar(&core.KubeContext, "context", "", "The kubeconfig context to use (defaults to the current context)")
 	rootCmd.PersistentFlags().BoolVar(&core.NoColor, "no-color", false, "Disable colored output in shell and query results")
 	rootCmd.PersistentFlags().BoolP("version", "v", false, "Show version and exit")
 	rootCmd.PersistentFlags().BoolVar(&DryRun, "dry-run", false, "Enable dry-run mode for all operations")

--- a/cmd/cyphernetes/root_test.go
+++ b/cmd/cyphernetes/root_test.go
@@ -6,7 +6,35 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/avitaltamir/cyphernetes/pkg/core"
 )
+
+func TestContextFlagRegistered(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("context")
+	if flag == nil {
+		t.Fatal("expected --context persistent flag to be registered")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("expected --context default to be empty, got %q", flag.DefValue)
+	}
+}
+
+func TestContextFlagBindsToCoreKubeContext(t *testing.T) {
+	original := core.KubeContext
+	defer func() {
+		core.KubeContext = original
+		// Reset the flag value so other tests start clean.
+		_ = rootCmd.PersistentFlags().Set("context", original)
+	}()
+
+	if err := rootCmd.PersistentFlags().Set("context", "my-context"); err != nil {
+		t.Fatalf("failed to set --context flag: %v", err)
+	}
+	if core.KubeContext != "my-context" {
+		t.Errorf("expected core.KubeContext to be %q, got %q", "my-context", core.KubeContext)
+	}
+}
 
 func TestExecuteNoArgs(t *testing.T) {
 	// Capture stdout

--- a/cmd/cyphernetes/shell.go
+++ b/cmd/cyphernetes/shell.go
@@ -58,7 +58,8 @@ var ShellCmd = &cobra.Command{
 
 		// Create provider with dry-run config
 		provider, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
-			DryRun: DryRun,
+			DryRun:  DryRun,
+			Context: core.KubeContext,
 		})
 		if err != nil {
 			fmt.Printf("Error creating provider: %v\n", err)
@@ -136,6 +137,9 @@ func getCurrentContext() (string, string, error) {
 func getCurrentContextFromConfig() (string, string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
+	if core.KubeContext != "" {
+		configOverrides.CurrentContext = core.KubeContext
+	}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
 	config, err := kubeConfig.RawConfig()
@@ -143,10 +147,15 @@ func getCurrentContextFromConfig() (string, string, error) {
 		return "", "", fmt.Errorf("error getting current context from kubeconfig: %v", err)
 	}
 
+	// Honor an explicit --context override, falling back to the kubeconfig's
+	// current-context when no override is set.
 	currentContextName := config.CurrentContext
+	if core.KubeContext != "" {
+		currentContextName = core.KubeContext
+	}
 	currentContext, exists := config.Contexts[currentContextName]
 	if !exists {
-		return "", "", fmt.Errorf("current context %s does not exist in kubeconfig", currentContextName)
+		return "", "", fmt.Errorf("context %s does not exist in kubeconfig", currentContextName)
 	}
 
 	namespace := currentContext.Namespace
@@ -267,7 +276,10 @@ type Listener interface {
 
 func initAndRunShell(_ *cobra.Command, _ []string) {
 	// Create the API server provider
-	p, err := apiserver.NewAPIServerProvider()
+	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
+		DryRun:  DryRun,
+		Context: core.KubeContext,
+	})
 	if err != nil {
 		fmt.Println("Error creating provider:", err)
 		os.Exit(1)

--- a/cmd/cyphernetes/shell_test.go
+++ b/cmd/cyphernetes/shell_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -345,6 +347,74 @@ func Test_describeRelationshipRule(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("describeRelationshipRule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+const shellTestKubeconfig = `apiVersion: v1
+kind: Config
+current-context: ctx-a
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://server-a.example.com
+- name: cluster-b
+  cluster:
+    server: https://server-b.example.com
+contexts:
+- name: ctx-a
+  context:
+    cluster: cluster-a
+    user: user-a
+    namespace: ns-a
+- name: ctx-b
+  context:
+    cluster: cluster-b
+    user: user-b
+    namespace: ns-b
+users:
+- name: user-a
+  user:
+    token: token-a
+- name: user-b
+  user:
+    token: token-b
+`
+
+func TestGetCurrentContextFromConfigHonorsKubeContext(t *testing.T) {
+	dir := t.TempDir()
+	kubeconfigPath := filepath.Join(dir, "config")
+	if err := os.WriteFile(kubeconfigPath, []byte(shellTestKubeconfig), 0o600); err != nil {
+		t.Fatalf("failed to write temp kubeconfig: %v", err)
+	}
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	originalKubeContext := core.KubeContext
+	defer func() { core.KubeContext = originalKubeContext }()
+
+	tests := []struct {
+		name        string
+		kubeContext string
+		wantContext string
+		wantNs      string
+	}{
+		{"defaults to current-context", "", "ctx-a", "ns-a"},
+		{"honors --context override", "ctx-b", "ctx-b", "ns-b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core.KubeContext = tt.kubeContext
+			gotContext, gotNs, err := getCurrentContextFromConfig()
+			if err != nil {
+				t.Fatalf("getCurrentContextFromConfig() returned error: %v", err)
+			}
+			if gotContext != tt.wantContext {
+				t.Errorf("context = %q, want %q", gotContext, tt.wantContext)
+			}
+			if gotNs != tt.wantNs {
+				t.Errorf("namespace = %q, want %q", gotNs, tt.wantNs)
 			}
 		})
 	}

--- a/cmd/cyphernetes/web.go
+++ b/cmd/cyphernetes/web.go
@@ -85,7 +85,8 @@ func runWeb(cmd *cobra.Command, args []string) {
 
 	// Create the API server provider
 	providerConfig := &apiserver.APIServerProviderConfig{
-		DryRun: DryRun,
+		DryRun:  DryRun,
+		Context: core.KubeContext,
 	}
 	provider, err := apiserver.NewAPIServerProviderWithOptions(providerConfig)
 	if err != nil {

--- a/cmd/kubectl-cypher/README.md
+++ b/cmd/kubectl-cypher/README.md
@@ -90,6 +90,9 @@ kubectl cypher -n kube-system "MATCH (p:Pod) RETURN p.metadata.name"
 # Query all namespaces
 kubectl cypher -A "MATCH (p:Pod) WHERE p.metadata.name CONTAINS 'nginx' RETURN p"
 
+# Query against a specific kubeconfig context
+kubectl cypher --context staging "MATCH (p:Pod) RETURN p.metadata.name"
+
 # Output in YAML format
 kubectl cypher --format yaml "MATCH (s:Service) RETURN s"
 
@@ -101,6 +104,7 @@ kubectl cypher --dry-run "MATCH (p:Pod) SET p.metadata.labels.new='value' RETURN
 
 - `-n, --namespace string`: The namespace to query against (default "default")
 - `-A, --all-namespaces`: Query all namespaces
+- `--context string`: The kubeconfig context to use (defaults to the current context)
 - `--format string`: Output format (json or yaml) (default "json")
 - `--dry-run`: Enable dry-run mode for all operations
 - `--no-color`: Disable colored output

--- a/cmd/kubectl-cypher/main.go
+++ b/cmd/kubectl-cypher/main.go
@@ -64,6 +64,7 @@ func runQuery(args []string, w io.Writer) {
 	p, err := apiserver.NewAPIServerProviderWithOptions(&apiserver.APIServerProviderConfig{
 		DryRun:    DryRun,
 		QuietMode: true,
+		Context:   core.KubeContext,
 	})
 	if err != nil {
 		fmt.Fprintln(w, "Error creating provider: ", err)
@@ -184,6 +185,7 @@ func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringVarP(&core.Namespace, "namespace", "n", "default", "The namespace to query against")
 	rootCmd.PersistentFlags().BoolVarP(&core.AllNamespaces, "all-namespaces", "A", false, "Query all namespaces")
+	rootCmd.PersistentFlags().StringVar(&core.KubeContext, "context", "", "The kubeconfig context to use (defaults to the current context)")
 	rootCmd.PersistentFlags().BoolVar(&core.NoColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&DryRun, "dry-run", false, "Enable dry-run mode for all operations")
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -27,6 +27,15 @@ sidebar_position: 4
   cyphernetes --context staging shell
   ```
 
+  **Which context is used** — Cyphernetes picks the first that applies:
+
+  1. `--context <name>` flag, if set (uses the kubeconfig, never in-cluster config).
+  2. In-cluster config, when running inside a Pod.
+  3. The kubeconfig's `current-context` (default).
+
+  The kubeconfig file itself is resolved the same way as `kubectl`: `$KUBECONFIG`
+  if set, otherwise `~/.kube/config`.
+
   This is independent of the in-query `IN` multi-context syntax
   (e.g. `IN prod, staging MATCH (p:Pod) RETURN p.metadata.name`); an explicit
   `IN` clause overrides `--context` for that query.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -15,6 +15,22 @@ sidebar_position: 4
   cyphernetes --dry-run web
   ```
 
+> Note: Selecting a Kubernetes context.
+
+  By default Cyphernetes uses your kubeconfig's current context. The global
+  `--context` flag lets you target a different context per invocation, just like
+  `kubectl --context`. It works with every command (`query`, `shell`, `web`,
+  `operator`) and respects the `KUBECONFIG` environment variable.
+
+  ```bash
+  cyphernetes --context staging query 'MATCH (p:Pod) RETURN p.metadata.name'
+  cyphernetes --context staging shell
+  ```
+
+  This is independent of the in-query `IN` multi-context syntax
+  (e.g. `IN prod, staging MATCH (p:Pod) RETURN p.metadata.name`); an explicit
+  `IN` clause overrides `--context` for that query.
+
 ## Shell
 
 Cyphernetes comes with a shell that lets you interactively query the Kubernetes API using Cyphernetes.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -29,9 +29,10 @@ sidebar_position: 4
 
   **Which context is used** — Cyphernetes picks the first that applies:
 
-  1. `--context <name>` flag, if set (uses the kubeconfig, never in-cluster config).
-  2. In-cluster config, when running inside a Pod.
-  3. The kubeconfig's `current-context` (default).
+  1. The context named by `--context`, read from your kubeconfig. Setting this
+     flag always uses the kubeconfig, even when running inside a Pod.
+  2. In-cluster config, when running inside a Pod and `--context` is not set.
+  3. The kubeconfig's `current-context`, when neither of the above applies.
 
   Cyphernetes reads your kubeconfig from `$KUBECONFIG` if that variable is set,
   and otherwise from `~/.kube/config` — the same as `kubectl`.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -33,8 +33,8 @@ sidebar_position: 4
   2. In-cluster config, when running inside a Pod.
   3. The kubeconfig's `current-context` (default).
 
-  The kubeconfig file itself is resolved the same way as `kubectl`: `$KUBECONFIG`
-  if set, otherwise `~/.kube/config`.
+  Cyphernetes reads your kubeconfig from `$KUBECONFIG` if that variable is set,
+  and otherwise from `~/.kube/config` — the same as `kubectl`.
 
   This is independent of the in-query `IN` multi-context syntax
   (e.g. `IN prod, staging MATCH (p:Pod) RETURN p.metadata.name`); an explicit

--- a/pkg/core/engine.go
+++ b/pkg/core/engine.go
@@ -38,13 +38,16 @@ type QueryExecutor struct {
 }
 
 var (
-	executorInstance  *QueryExecutor
-	contextExecutors  map[string]*QueryExecutor
-	once              sync.Once
-	GvrCache          map[string]schema.GroupVersionResource
-	ResourceSpecs     map[string][]string
-	executorsLock     sync.RWMutex
-	Namespace         string
+	executorInstance *QueryExecutor
+	contextExecutors map[string]*QueryExecutor
+	once             sync.Once
+	GvrCache         map[string]schema.GroupVersionResource
+	ResourceSpecs    map[string][]string
+	executorsLock    sync.RWMutex
+	Namespace        string
+	// KubeContext is the kubeconfig context to use. When empty, the kubeconfig's
+	// current-context is used. Set via the global --context CLI flag.
+	KubeContext       string
 	LogLevel          string
 	OutputFormat      string
 	AllNamespaces     bool

--- a/pkg/provider/apiserver/provider.go
+++ b/pkg/provider/apiserver/provider.go
@@ -33,8 +33,12 @@ type APIServerProviderConfig struct {
 	Clientset     kubernetes.Interface
 	DynamicClient dynamic.Interface
 	Kubeconfig    *rest.Config
-	DryRun        bool
-	QuietMode     bool
+	// Context is the kubeconfig context to use. When set, it takes precedence
+	// over Kubeconfig and the in-cluster config and forces loading from the
+	// kubeconfig with the given context as current-context.
+	Context   string
+	DryRun    bool
+	QuietMode bool
 }
 
 type APIServerProvider struct {
@@ -72,6 +76,20 @@ func NewAPIServerProvider() (provider.Provider, error) {
 	})
 }
 
+// buildRestConfigFromKubeconfig loads a *rest.Config from the standard kubeconfig
+// loading rules (honoring the KUBECONFIG env var and $HOME/.kube/config). When
+// context is non-empty it overrides the kubeconfig's current-context, mirroring
+// kubectl's --context flag.
+func buildRestConfigFromKubeconfig(context string) (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	if context != "" {
+		configOverrides.CurrentContext = context
+	}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	return kubeConfig.ClientConfig()
+}
+
 func NewAPIServerProviderWithOptions(config *APIServerProviderConfig) (provider.Provider, error) {
 	var err error
 	clientset := config.Clientset
@@ -80,8 +98,20 @@ func NewAPIServerProviderWithOptions(config *APIServerProviderConfig) (provider.
 	// If clients are not provided, create them
 	if clientset == nil || dynamicClient == nil {
 		var restConfig *rest.Config
+		// Config selection precedence:
+		//   1. An explicit context (--context) forces loading from the kubeconfig
+		//      with that context as current-context, ignoring in-cluster config.
+		//   2. A caller-provided *rest.Config (Kubeconfig).
+		//   3. In-cluster config when running inside a pod.
+		//   4. The default kubeconfig (KUBECONFIG env or $HOME/.kube/config).
+		if config.Context != "" {
+			restConfig, err = buildRestConfigFromKubeconfig(config.Context)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create config for context %s: %v", config.Context, err)
+			}
+		}
 		// If user provided a kubeconfig, use that.
-		if config.Kubeconfig != nil {
+		if restConfig == nil && config.Kubeconfig != nil {
 			restConfig = config.Kubeconfig
 		}
 		// If caller did not provide a kubeconfig, try in-cluster config first
@@ -95,10 +125,7 @@ func NewAPIServerProviderWithOptions(config *APIServerProviderConfig) (provider.
 		// nor the caller provided a kubeconfig,
 		// try loading the config from KUBECONFIG env or $HOME/.kube/config file
 		if restConfig == nil {
-			loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-			configOverrides := &clientcmd.ConfigOverrides{}
-			kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-			restConfig, err = kubeConfig.ClientConfig()
+			restConfig, err = buildRestConfigFromKubeconfig("")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create config: %v", err)
 			}
@@ -1144,15 +1171,8 @@ func (p *APIServerProvider) resolveReference(ref string) *openapi_v3.Schema {
 
 // Add this method to implement the Provider interface
 func (p *APIServerProvider) CreateProviderForContext(context string) (provider.Provider, error) {
-	// Create new config for the context
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{
-		CurrentContext: context,
-	}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-
 	// Get REST config for the context
-	restConfig, err := kubeConfig.ClientConfig()
+	restConfig, err := buildRestConfigFromKubeconfig(context)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config for context %s: %v", context, err)
 	}

--- a/pkg/provider/apiserver/provider_test.go
+++ b/pkg/provider/apiserver/provider_test.go
@@ -1,0 +1,95 @@
+package apiserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const twoContextKubeconfig = `apiVersion: v1
+kind: Config
+current-context: ctx-a
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://server-a.example.com
+- name: cluster-b
+  cluster:
+    server: https://server-b.example.com
+contexts:
+- name: ctx-a
+  context:
+    cluster: cluster-a
+    user: user-a
+    namespace: ns-a
+- name: ctx-b
+  context:
+    cluster: cluster-b
+    user: user-b
+    namespace: ns-b
+users:
+- name: user-a
+  user:
+    token: token-a
+- name: user-b
+  user:
+    token: token-b
+`
+
+func writeTempKubeconfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	if err := os.WriteFile(path, []byte(twoContextKubeconfig), 0o600); err != nil {
+		t.Fatalf("failed to write temp kubeconfig: %v", err)
+	}
+	return path
+}
+
+func TestBuildRestConfigFromKubeconfig(t *testing.T) {
+	kubeconfigPath := writeTempKubeconfig(t)
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	tests := []struct {
+		name       string
+		context    string
+		wantServer string
+	}{
+		{
+			name:       "empty context uses current-context",
+			context:    "",
+			wantServer: "https://server-a.example.com",
+		},
+		{
+			name:       "explicit context overrides current-context",
+			context:    "ctx-b",
+			wantServer: "https://server-b.example.com",
+		},
+		{
+			name:       "explicit current-context still resolves",
+			context:    "ctx-a",
+			wantServer: "https://server-a.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := buildRestConfigFromKubeconfig(tt.context)
+			if err != nil {
+				t.Fatalf("buildRestConfigFromKubeconfig(%q) returned error: %v", tt.context, err)
+			}
+			if cfg.Host != tt.wantServer {
+				t.Errorf("buildRestConfigFromKubeconfig(%q) host = %q, want %q", tt.context, cfg.Host, tt.wantServer)
+			}
+		})
+	}
+}
+
+func TestBuildRestConfigFromKubeconfigUnknownContext(t *testing.T) {
+	kubeconfigPath := writeTempKubeconfig(t)
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	if _, err := buildRestConfigFromKubeconfig("does-not-exist"); err == nil {
+		t.Fatalf("expected error for unknown context, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #251. Adds a global `--context` flag (like `kubectl --context`) so users with many kubeconfig contexts can pick the target cluster per-invocation instead of relying on the kubeconfig's `current-context`. Mirrors the existing `--namespace`/`-n` flag.

The flag is honored by every command — `query`, `shell`, `web`, `operator` — and by the `kubectl-cypher` plugin. It respects the `KUBECONFIG` environment variable and defaults to the current context when unset.

## What changed

- **`core.KubeContext`** added; persistent `--context` flag registered in both `cmd/cyphernetes/root.go` and `cmd/kubectl-cypher/main.go`.
- **Provider**: new `Context` field on `APIServerProviderConfig`. A shared `buildRestConfigFromKubeconfig` helper applies `clientcmd.ConfigOverrides{CurrentContext: ...}`; an explicit context skips in-cluster config. `CreateProviderForContext` now reuses the helper. Precedence: `Context` > provided `Kubeconfig` > in-cluster > default kubeconfig.
- **Threaded** the context into all client-construction sites (query x2, shell x2, web, api `convert-resource-name`, kubectl-cypher).
- **Shell prompt** and the web `/api/context` endpoint now reflect the chosen context (and its default namespace).
- **Operator** `deploy`/`remove` switched from a hardcoded `~/.kube/config` (which also ignored `KUBECONFIG`) to deferred-loading client config that honors both `KUBECONFIG` and `--context`.
- The in-query `IN ctx1, ctx2` multi-context syntax is unaffected and still overrides `--context` per query.

## Testing

- **Unit tests**: new `pkg/provider/apiserver/provider_test.go` (temp two-context kubeconfig, asserts the override selects the right cluster server + errors on unknown context); `--context` flag registration/binding test; shell `getCurrentContextFromConfig` override test.
- `go test ./...` passes (incl. e2e); `pkg/core` coverage 80.8% (≥ 80% floor).
- **Manual against minikube** (with a second alias context):
  - default context, explicit `--context minikube`, and `--context mk-alias` all query the expected cluster/namespace
  - invalid `--context` → clear error: `context "does-not-exist" does not exist`
  - shell prompt shows `(mk-alias) kube-system »`
  - `IN minikube, mk-alias MATCH ...` still works

