### PR TITLE
chore: add Qodo Merge config and PR compliance checklist

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,37 @@
+[github_app]
+feedback_or_draft_pr = false
+handle_push_trigger = true
+pr_commands = ["/agentic_review"]
+push_commands = ["/agentic_review"]
+
+[auto_best_practices]
+enable_auto_best_practices = true
+utilize_auto_best_practices = true
+
+[checks]
+enable_auto_checks_feedback = false
+
+[config]
+publish_output_progress = false
+
+[pr_code_suggestions]
+enable_chat_in_code_suggestions = true
+
+[review_agent]
+enabled = true
+approve_pr_on_self_review = true
+comments_location_policy = "summary"
+demand_self_review = true
+final_update_message = false
+persistent_comment = true
+persistent_comment_notification = false
+publish_output = true
+
+[review_agent_ux]
+finding_overflow_count = "all"
+expand_description = true
+expand_code = false
+expand_relevance = false
+expand_evidence = false
+expand_prompt = true
+resolved_overflow_count = "none"

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -1,0 +1,24 @@
+pr_compliances:
+    - title: "Docs updated for user-facing changes"
+      compliance_label: true
+      objective: "Docs reflect public API, CLI, or query-language changes."
+      success_criteria: "Docs under docs/ (including LANGUAGE.md) or examples update with user-facing changes."
+      failure_criteria: "User-facing changes without doc updates."
+
+    - title: "Tests colocated with the code they cover"
+      compliance_label: true
+      objective: "New behavior is covered by Go tests next to the code under test."
+      success_criteria: "Changes add or update _test.go files in the same package, with an issue reference in a test comment when fixing a reported issue."
+      failure_criteria: "New or changed behavior lands without corresponding test coverage."
+
+    - title: "Consistent Naming Conventions"
+      compliance_label: true
+      objective: "All new identifiers follow Go and project naming standards."
+      success_criteria: "Identifiers follow Go conventions (MixedCaps/PascalCase for exported, mixedCaps for unexported, no underscores) and match surrounding code."
+      failure_criteria: "Inconsistent or non-standard naming that deviates from Go and project conventions."
+
+    - title: "Remove AI-generated noise"
+      compliance_label: true
+      objective: "Changes should not introduce AI-generated slop."
+      success_criteria: "No extra comments, abnormal defensive checks, swallowed errors, interface{}/any casts to bypass types, or style inconsistent with the file."
+      failure_criteria: "Added AI-like comments, abnormal defensive code, ignored errors, type-bypassing casts, or inconsistent style."


### PR DESCRIPTION
Mirrors TypeORM's Qodo setup with two repo-root files.

## `.pr_agent.toml`
Copied verbatim from TypeORM (tool config, not language-specific): agentic review on PR open and push, auto best-practices, summary-located comments, self-review/auto-approve flow, and matching review-agent UX settings.

## `pr_compliance_checklist.yaml`
Same four-check structure, with the three project-specific checks adapted for cyphernetes' Go conventions:
- **Docs updated** — points at `docs/` and `LANGUAGE.md` for API/CLI/query-language changes.
- **Tests colocated with code** — replaces TypeORM's functional-test rule; expects `_test.go` in the same package, with an issue ref when fixing a reported issue.
- **Naming conventions** — Go rules (MixedCaps/mixedCaps, no underscores) instead of JS camelCase/snake_case.
- **Remove AI-generated noise** — Go equivalents (`interface{}`/`any` casts, swallowed errors) instead of TS any-casts.

## Note
Qodo Merge needs the Qodo GitHub App installed on the repo for these to take effect (admin step outside this PR). Push triggers (`/agentic_review` on every push) are kept identical to TypeORM — can be trimmed to PR-only if too noisy.